### PR TITLE
Fix long blank area on terms page

### DIFF
--- a/algosone-ai/pages/terms/algosone.ai/terms/index.html
+++ b/algosone-ai/pages/terms/algosone.ai/terms/index.html
@@ -295,7 +295,7 @@
     ></script>
   </head>
   <body
-    class="wp-singular page-template-default page page-id-518 wp-embed-responsive wp-theme-common tt-transition tt-boxed tt-smooth-scroll tt-magic-cursor is-chrome"
+    class="wp-singular page-template-default page page-id-518 wp-embed-responsive wp-theme-common tt-transition tt-boxed tt-magic-cursor is-chrome"
   >
     <noscript
       ><iframe


### PR DESCRIPTION
## Summary
- remove `tt-smooth-scroll` class from terms page body so default scrolling works

## Testing
- `pip install beautifulsoup4`

------
https://chatgpt.com/codex/tasks/task_e_685903fce1e083208e7b583eb14a9a26