### PR TITLE
Remove obsolete links from Markets page

### DIFF
--- a/algosone-ai/pages/markets/algosone.ai/markets/index.html
+++ b/algosone-ai/pages/markets/algosone.ai/markets/index.html
@@ -135,45 +135,14 @@ gtag("config", "GT-WR9QBQT");
        </div>
        <div class="col-middle">
         <div class="menu" id="menu-header-1">
-         <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children" id="nav-menu-item-487">
-          <a class="magnetic-item-off menu-link main-menu-link" href="https://algosone.ai/ai-trading/">
-           AI Trading
+         <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1584">
+          <a class="magnetic-item-off menu-link main-menu-link" href="https://algosone.ai/ai-crypto-trading/">
+           AI Crypto Trading
           </a>
-          <ul class="sub-menu menu-odd menu-depth-1">
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1584">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/ai-crypto-trading/">
-             AI Crypto Trading
-            </a>
-            <span class="description">
-             Profit from a wide range of crypto assets.
-            </span>
-           </li>
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1585">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/ai-forex-trading/">
-             AI Forex Trading
-            </a>
-            <span class="description">
-             Enjoy trading on hundreds of currency pairs.
-            </span>
-           </li>
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1586">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/ai-stocks-trading/">
-             AI Stocks Trading
-            </a>
-            <span class="description">
-             Benefit from rising and falling stock prices.
-            </span>
-           </li>
-          </ul>
          </li>
          <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-37">
           <a class="magnetic-item-off menu-link main-menu-link" href="https://algosone.ai/technology/">
            Technology
-          </a>
-         </li>
-         <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-288">
-          <a class="magnetic-item-off menu-link main-menu-link" href="https://algosone.ai/trading/">
-           Trading Tiers
           </a>
          </li>
          <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-486">
@@ -202,22 +171,6 @@ gtag("config", "GT-WR9QBQT");
              See what makes us stand out from the crowd.
             </span>
            </li>
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-282">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/shares/">
-             Shares
-            </a>
-            <span class="description">
-             Get a share in our platform’s global success.
-            </span>
-           </li>
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-custom menu-item-object-custom" id="nav-menu-item-558">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="/news/">
-             News
-            </a>
-            <span class="description">
-             Find out what the press has to say about us.
-            </span>
-           </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-626">
             <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/affiliates/">
              Affiliates
@@ -234,44 +187,12 @@ gtag("config", "GT-WR9QBQT");
              Introduce your followers to a great opportunity.
             </span>
            </li>
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1123">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/media-kit/">
-             Media Kit
-            </a>
-            <span class="description">
-             Access eye-catching marketing content.
-            </span>
-           </li>
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-35">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/blog/">
-             Blog
-            </a>
-            <span class="description">
-             Learn about a wide range of financial topics.
-            </span>
-           </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-289">
             <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/faq/">
              FAQ
             </a>
             <span class="description">
              Have a question? We’ve got the answer.
-            </span>
-           </li>
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-custom menu-item-object-custom" id="nav-menu-item-1514">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://help.algosone.ai/" target="_blank">
-             Help Center
-            </a>
-            <span class="description">
-             Welcome to our Help Center
-            </span>
-           </li>
-           <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1662">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/roadmap/">
-             Roadmap
-            </a>
-            <span class="description">
-             Check out what we have in the pipeline.
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1480">
@@ -391,36 +312,14 @@ gtag("config", "GT-WR9QBQT");
           <div class="tt-ol-menu-inner tt-wrap">
            <div class="tt-ol-menu-content">
             <ul class="tt-ol-menu-list" id="menu-header-2">
-             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-487" id="menu-item-487">
-              <a href="https://algosone.ai/ai-trading/" itemprop="url">
-               AI Trading
-              </a>
-              <ul class="sub-menu">
-               <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1584" id="menu-item-1584">
+               <li class="menu-item menu-item-type-post_type menu-item-object-page" id="menu-item-1584">
                 <a href="https://algosone.ai/ai-crypto-trading/" itemprop="url">
                  AI Crypto Trading
                 </a>
                </li>
-               <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1585" id="menu-item-1585">
-                <a href="https://algosone.ai/ai-forex-trading/" itemprop="url">
-                 AI Forex Trading
-                </a>
-               </li>
-               <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1586" id="menu-item-1586">
-                <a href="https://algosone.ai/ai-stocks-trading/" itemprop="url">
-                 AI Stocks Trading
-                </a>
-               </li>
-              </ul>
-             </li>
              <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37" id="menu-item-37">
               <a href="https://algosone.ai/technology/" itemprop="url">
                Technology
-              </a>
-             </li>
-             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-288" id="menu-item-288">
-              <a href="https://algosone.ai/trading/" itemprop="url">
-               Trading Tiers
               </a>
              </li>
              <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-486" id="menu-item-486">
@@ -443,16 +342,6 @@ gtag("config", "GT-WR9QBQT");
                  About
                 </a>
                </li>
-               <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-282" id="menu-item-282">
-                <a href="https://algosone.ai/shares/" itemprop="url">
-                 Shares
-                </a>
-               </li>
-               <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-558" id="menu-item-558">
-                <a href="/news/" itemprop="url">
-                 News
-                </a>
-               </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-626" id="menu-item-626">
                 <a href="https://algosone.ai/affiliates/" itemprop="url">
                  Affiliates
@@ -463,29 +352,9 @@ gtag("config", "GT-WR9QBQT");
                  Influencers
                 </a>
                </li>
-               <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1123" id="menu-item-1123">
-                <a href="https://algosone.ai/media-kit/" itemprop="url">
-                 Media Kit
-                </a>
-               </li>
-               <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-35" id="menu-item-35">
-                <a href="https://algosone.ai/blog/" itemprop="url">
-                 Blog
-                </a>
-               </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289" id="menu-item-289">
                 <a href="https://algosone.ai/faq/" itemprop="url">
                  FAQ
-                </a>
-               </li>
-               <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1514" id="menu-item-1514">
-                <a href="https://help.algosone.ai/" itemprop="url" target="_blank">
-                 Help Center
-                </a>
-               </li>
-               <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1662" id="menu-item-1662">
-                <a href="https://algosone.ai/roadmap/" itemprop="url">
-                 Roadmap
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1480" id="menu-item-1480">
@@ -771,34 +640,14 @@ gtag("config", "GT-WR9QBQT");
             Get to Know Us
            </div>
            <ul class="menu" id="menu-menu-footer-1">
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-493" id="menu-item-493">
-             <a href="https://algosone.ai/ai-trading/" itemprop="url">
-              AI Trading
-             </a>
-            </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590" id="menu-item-1590">
              <a href="https://algosone.ai/ai-crypto-trading/" itemprop="url">
               AI Crypto Trading
              </a>
             </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1591" id="menu-item-1591">
-             <a href="https://algosone.ai/ai-forex-trading/" itemprop="url">
-              AI Forex Trading
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1592" id="menu-item-1592">
-             <a href="https://algosone.ai/ai-stocks-trading/" itemprop="url">
-              AI Stocks Trading
-             </a>
-            </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18" id="menu-item-18">
              <a href="https://algosone.ai/technology/" itemprop="url">
               Technology
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-20" id="menu-item-20">
-             <a href="https://algosone.ai/trading/" itemprop="url">
-              Trading Tiers
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-21 current_page_item menu-item-499" id="menu-item-499">
@@ -838,36 +687,6 @@ gtag("config", "GT-WR9QBQT");
               About
              </a>
             </li>
-            <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-559" id="menu-item-559">
-             <a href="/news/" itemprop="url">
-              News
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-504" id="menu-item-504">
-             <a href="https://algosone.ai/blog/" itemprop="url">
-              Blog
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-349" id="menu-item-349">
-             <a href="https://algosone.ai/shares/" itemprop="url">
-              Shares
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-3029" id="menu-item-3029">
-             <a href="https://help.algosone.ai/" itemprop="url" target="_blank">
-              Help Center
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1140" id="menu-item-1140">
-             <a href="https://algosone.ai/media-kit/" itemprop="url">
-              Media Kit
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1663" id="menu-item-1663">
-             <a href="https://algosone.ai/roadmap/" itemprop="url">
-              Roadmap
-             </a>
-            </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-502" id="menu-item-502">
              <a href="https://algosone.ai/faq/" itemprop="url">
               FAQ
@@ -876,16 +695,6 @@ gtag("config", "GT-WR9QBQT");
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3017" id="menu-item-3017">
              <a href="https://algosone.ai/reviews/" itemprop="url">
               AlgosOne Reviews
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-3437" id="menu-item-3437">
-             <a href="https://algosone.ai/ai-crypto-signals-staying-one-step-ahead-of-the-trend/" itemprop="url">
-              AI Crypto Signals
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-9765" id="menu-item-9765">
-             <a href="https://algosone.ai/ai-crypto-arbitrage-gain-the-strategic-advantage/" itemprop="url">
-              AI Crypto Arbitrage
              </a>
             </li>
            </ul>
@@ -908,11 +717,6 @@ gtag("config", "GT-WR9QBQT");
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy menu-item-485" id="menu-item-485">
              <a href="https://algosone.ai/privacy-policy/" itemprop="url" rel="privacy-policy">
               Privacy Policy
-             </a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-482" id="menu-item-482">
-             <a href="https://algosone.ai/risk-disclaimer/" itemprop="url">
-              Risk Disclaimer
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-483" id="menu-item-483">


### PR DESCRIPTION
## Summary
- remove links to deprecated pages from the Markets page
- keep language options and add direct link to AI Crypto Trading

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68591d0a21b483209f7be6f7cdc10bc1