### PR TITLE
Remove obsolete links from affiliates page

### DIFF
--- a/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html
+++ b/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html
@@ -349,54 +349,6 @@
               <div class="col-middle">
                 <div id="menu-header-1" class="menu">
                   <li
-                    id="nav-menu-item-487"
-                    class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children"
-                  >
-                    <a
-                      href="https://algosone.ai/ai-trading/"
-                      class="magnetic-item-off menu-link main-menu-link"
-                      >AI Trading</a
-                    >
-                    <ul class="sub-menu menu-odd menu-depth-1">
-                      <li
-                        id="nav-menu-item-1584"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/ai-crypto-trading/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >AI Crypto Trading</a
-                        ><span class="description"
-                          >Profit from a wide range of crypto assets.</span
-                        >
-                      </li>
-                      <li
-                        id="nav-menu-item-1585"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/ai-forex-trading/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >AI Forex Trading</a
-                        ><span class="description"
-                          >Enjoy trading on hundreds of currency pairs.</span
-                        >
-                      </li>
-                      <li
-                        id="nav-menu-item-1586"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/ai-stocks-trading/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >AI Stocks Trading</a
-                        ><span class="description"
-                          >Benefit from rising and falling stock prices.</span
-                        >
-                      </li>
-                    </ul>
-                  </li>
-                  <li
                     id="nav-menu-item-37"
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
                   >
@@ -404,16 +356,6 @@
                       href="https://algosone.ai/technology/"
                       class="magnetic-item-off menu-link main-menu-link"
                       >Technology</a
-                    >
-                  </li>
-                  <li
-                    id="nav-menu-item-288"
-                    class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
-                  >
-                    <a
-                      href="https://algosone.ai/trading/"
-                      class="magnetic-item-off menu-link main-menu-link"
-                      >Trading Tiers</a
                     >
                   </li>
                   <li
@@ -459,30 +401,6 @@
                         >
                       </li>
                       <li
-                        id="nav-menu-item-282"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/shares/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >Shares</a
-                        ><span class="description"
-                          >Get a share in our platform’s global success.</span
-                        >
-                      </li>
-                      <li
-                        id="nav-menu-item-558"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-custom menu-item-object-custom"
-                      >
-                        <a
-                          href="/news/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >News</a
-                        ><span class="description"
-                          >Find out what the press has to say about us.</span
-                        >
-                      </li>
-                      <li
                         id="nav-menu-item-626"
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-603 current_page_item"
                       >
@@ -508,30 +426,6 @@
                         >
                       </li>
                       <li
-                        id="nav-menu-item-1123"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/media-kit/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >Media Kit</a
-                        ><span class="description"
-                          >Access eye-catching marketing content.</span
-                        >
-                      </li>
-                      <li
-                        id="nav-menu-item-35"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/blog/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >Blog</a
-                        ><span class="description"
-                          >Learn about a wide range of financial topics.</span
-                        >
-                      </li>
-                      <li
                         id="nav-menu-item-289"
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
@@ -541,31 +435,6 @@
                           >FAQ</a
                         ><span class="description"
                           >Have a question? We’ve got the answer.</span
-                        >
-                      </li>
-                      <li
-                        id="nav-menu-item-1514"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-custom menu-item-object-custom"
-                      >
-                        <a
-                          target="_blank"
-                          href="https://help.algosone.ai/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >Help Center</a
-                        ><span class="description"
-                          >Welcome to our Help Center</span
-                        >
-                      </li>
-                      <li
-                        id="nav-menu-item-1662"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/roadmap/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >Roadmap</a
-                        ><span class="description"
-                          >Check out what we have in the pipeline.</span
                         >
                       </li>
                       <li
@@ -725,48 +594,6 @@
                       <div class="tt-ol-menu-content">
                         <ul id="menu-header-2" class="tt-ol-menu-list">
                           <li
-                            id="menu-item-487"
-                            class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-487"
-                          >
-                            <a
-                              href="https://algosone.ai/ai-trading/"
-                              itemprop="url"
-                              >AI Trading</a
-                            >
-                            <ul class="sub-menu">
-                              <li
-                                id="menu-item-1584"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1584"
-                              >
-                                <a
-                                  href="https://algosone.ai/ai-crypto-trading/"
-                                  itemprop="url"
-                                  >AI Crypto Trading</a
-                                >
-                              </li>
-                              <li
-                                id="menu-item-1585"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1585"
-                              >
-                                <a
-                                  href="https://algosone.ai/ai-forex-trading/"
-                                  itemprop="url"
-                                  >AI Forex Trading</a
-                                >
-                              </li>
-                              <li
-                                id="menu-item-1586"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1586"
-                              >
-                                <a
-                                  href="https://algosone.ai/ai-stocks-trading/"
-                                  itemprop="url"
-                                  >AI Stocks Trading</a
-                                >
-                              </li>
-                            </ul>
-                          </li>
-                          <li
                             id="menu-item-37"
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"
                           >
@@ -774,16 +601,6 @@
                               href="https://algosone.ai/technology/"
                               itemprop="url"
                               >Technology</a
-                            >
-                          </li>
-                          <li
-                            id="menu-item-288"
-                            class="menu-item menu-item-type-post_type menu-item-object-page menu-item-288"
-                          >
-                            <a
-                              href="https://algosone.ai/trading/"
-                              itemprop="url"
-                              >Trading Tiers</a
                             >
                           </li>
                           <li
@@ -823,22 +640,6 @@
                                 >
                               </li>
                               <li
-                                id="menu-item-282"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-282"
-                              >
-                                <a
-                                  href="https://algosone.ai/shares/"
-                                  itemprop="url"
-                                  >Shares</a
-                                >
-                              </li>
-                              <li
-                                id="menu-item-558"
-                                class="menu-item menu-item-type-custom menu-item-object-custom menu-item-558"
-                              >
-                                <a href="/news/" itemprop="url">News</a>
-                              </li>
-                              <li
                                 id="menu-item-626"
                                 class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-603 current_page_item menu-item-626"
                               >
@@ -860,26 +661,6 @@
                                 >
                               </li>
                               <li
-                                id="menu-item-1123"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1123"
-                              >
-                                <a
-                                  href="https://algosone.ai/media-kit/"
-                                  itemprop="url"
-                                  >Media Kit</a
-                                >
-                              </li>
-                              <li
-                                id="menu-item-35"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-35"
-                              >
-                                <a
-                                  href="https://algosone.ai/blog/"
-                                  itemprop="url"
-                                  >Blog</a
-                                >
-                              </li>
-                              <li
                                 id="menu-item-289"
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289"
                               >
@@ -887,27 +668,6 @@
                                   href="https://algosone.ai/faq/"
                                   itemprop="url"
                                   >FAQ</a
-                                >
-                              </li>
-                              <li
-                                id="menu-item-1514"
-                                class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1514"
-                              >
-                                <a
-                                  target="_blank"
-                                  href="https://help.algosone.ai/"
-                                  itemprop="url"
-                                  >Help Center</a
-                                >
-                              </li>
-                              <li
-                                id="menu-item-1662"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1662"
-                              >
-                                <a
-                                  href="https://algosone.ai/roadmap/"
-                                  itemprop="url"
-                                  >Roadmap</a
                                 >
                               </li>
                               <li
@@ -1416,46 +1176,6 @@
                       <div class="f-head text-center">Get to Know Us</div>
                       <ul id="menu-menu-footer-1" class="menu">
                         <li
-                          id="menu-item-493"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-493"
-                        >
-                          <a
-                            href="https://algosone.ai/ai-trading/"
-                            itemprop="url"
-                            >AI Trading</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-1590"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590"
-                        >
-                          <a
-                            href="https://algosone.ai/ai-crypto-trading/"
-                            itemprop="url"
-                            >AI Crypto Trading</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-1591"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1591"
-                        >
-                          <a
-                            href="https://algosone.ai/ai-forex-trading/"
-                            itemprop="url"
-                            >AI Forex Trading</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-1592"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1592"
-                        >
-                          <a
-                            href="https://algosone.ai/ai-stocks-trading/"
-                            itemprop="url"
-                            >AI Stocks Trading</a
-                          >
-                        </li>
-                        <li
                           id="menu-item-18"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"
                         >
@@ -1463,14 +1183,6 @@
                             href="https://algosone.ai/technology/"
                             itemprop="url"
                             >Technology</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-20"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-20"
-                        >
-                          <a href="https://algosone.ai/trading/" itemprop="url"
-                            >Trading Tiers</a
                           >
                         </li>
                         <li
@@ -1536,57 +1248,6 @@
                           >
                         </li>
                         <li
-                          id="menu-item-559"
-                          class="menu-item menu-item-type-custom menu-item-object-custom menu-item-559"
-                        >
-                          <a href="/news/" itemprop="url">News</a>
-                        </li>
-                        <li
-                          id="menu-item-504"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-504"
-                        >
-                          <a href="https://algosone.ai/blog/" itemprop="url"
-                            >Blog</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-349"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-349"
-                        >
-                          <a href="https://algosone.ai/shares/" itemprop="url"
-                            >Shares</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-3029"
-                          class="menu-item menu-item-type-custom menu-item-object-custom menu-item-3029"
-                        >
-                          <a
-                            target="_blank"
-                            href="https://help.algosone.ai/"
-                            itemprop="url"
-                            >Help Center</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-1140"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1140"
-                        >
-                          <a
-                            href="https://algosone.ai/media-kit/"
-                            itemprop="url"
-                            >Media Kit</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-1663"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1663"
-                        >
-                          <a href="https://algosone.ai/roadmap/" itemprop="url"
-                            >Roadmap</a
-                          >
-                        </li>
-                        <li
                           id="menu-item-502"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-502"
                         >
@@ -1600,26 +1261,6 @@
                         >
                           <a href="https://algosone.ai/reviews/" itemprop="url"
                             >AlgosOne Reviews</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-3437"
-                          class="menu-item menu-item-type-custom menu-item-object-custom menu-item-3437"
-                        >
-                          <a
-                            href="https://algosone.ai/ai-crypto-signals-staying-one-step-ahead-of-the-trend/"
-                            itemprop="url"
-                            >AI Crypto Signals</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-9765"
-                          class="menu-item menu-item-type-custom menu-item-object-custom menu-item-9765"
-                        >
-                          <a
-                            href="https://algosone.ai/ai-crypto-arbitrage-gain-the-strategic-advantage/"
-                            itemprop="url"
-                            >AI Crypto Arbitrage</a
                           >
                         </li>
                       </ul>
@@ -1654,16 +1295,6 @@
                             href="https://algosone.ai/privacy-policy/"
                             itemprop="url"
                             >Privacy Policy</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-482"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-482"
-                        >
-                          <a
-                            href="https://algosone.ai/risk-disclaimer/"
-                            itemprop="url"
-                            >Risk Disclaimer</a
                           >
                         </li>
                         <li


### PR DESCRIPTION
## Summary
- remove deprecated navigation links from affiliates page

## Testing
- `grep -n "AI Forex Trading" algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685923a0b8cc8320897b3684b9b3722b