### PR TITLE
Fix loader stuck on terms page

### DIFF
--- a/algosone-ai/pages/terms/algosone.ai/terms/index.html
+++ b/algosone-ai/pages/terms/algosone.ai/terms/index.html
@@ -2490,6 +2490,17 @@
                               >Risk Disclaimer</a
                             >
                           </li>
+<script>
+  window.addEventListener('load', function () {
+    const interval = setInterval(function () {
+      if (document.body.classList.contains('page-loaded')) {
+        const el = document.getElementById('page-transition');
+        if (el) el.style.display = 'none';
+        clearInterval(interval);
+      }
+    }, 50);
+  });
+</script>
                           <li
                             id="menu-item-483"
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-483"


### PR DESCRIPTION
## Summary
- add fallback JS to hide the preloader once loading completes

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68595716da4883209485c7897522f334