### PR TITLE
Remove outdated links from home page

### DIFF
--- a/algosone-ai/pages/home/algosone.ai/index.html
+++ b/algosone-ai/pages/home/algosone.ai/index.html
@@ -404,19 +404,6 @@
                         >
                       </li>
                       <li
-                        id="nav-menu-item-627"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/influencers/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >Influencers</a
-                        ><span class="description"
-                          >Introduce your followers to a great
-                          opportunity.</span
-                        >
-                      </li>
-                      <li
                         id="nav-menu-item-289"
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
@@ -640,16 +627,6 @@
                                   href="https://algosone.ai/affiliates/"
                                   itemprop="url"
                                   >Affiliates</a
-                                >
-                              </li>
-                              <li
-                                id="menu-item-627"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-627"
-                              >
-                                <a
-                                  href="https://algosone.ai/influencers/"
-                                  itemprop="url"
-                                  >Influencers</a
                                 >
                               </li>
                               <li
@@ -2645,16 +2622,6 @@
                           >
                         </li>
                         <li
-                          id="menu-item-667"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-667"
-                        >
-                          <a
-                            href="https://algosone.ai/influencers/"
-                            itemprop="url"
-                            >Influencers</a
-                          >
-                        </li>
-                        <li
                           id="menu-item-9916"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9916"
                         >
@@ -2699,24 +2666,6 @@
                       <div class="f-head text-center">Let Us Help You</div>
                       <ul id="menu-menu-footer-3" class="menu">
                         <li
-                          id="menu-item-528"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-528"
-                        >
-                          <a href="https://algosone.ai/terms/" itemprop="url"
-                            >Terms & Conditions</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-481"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-481"
-                        >
-                          <a
-                            href="https://algosone.ai/aml-policy/"
-                            itemprop="url"
-                            >AML Policy</a
-                          >
-                        </li>
-                        <li
                           id="menu-item-485"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy menu-item-485"
                         >
@@ -2725,24 +2674,6 @@
                             href="https://algosone.ai/privacy-policy/"
                             itemprop="url"
                             >Privacy Policy</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-483"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-483"
-                        >
-                          <a
-                            href="https://algosone.ai/cookie-policy/"
-                            itemprop="url"
-                            >Cookie Policy</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-484"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-484"
-                        >
-                          <a href="https://algosone.ai/sitemap/" itemprop="url"
-                            >Sitemap</a
                           >
                         </li>
                       </ul>


### PR DESCRIPTION
## Summary
- clean up navigation and footer on home page by removing links to deleted pages

## Testing
- `grep -n "influencers" algosone-ai/pages/home/algosone.ai/index.html`


------
https://chatgpt.com/codex/tasks/task_e_685a6f50fb4c83209d82bbd259deb85d