### PR TITLE
Remove outdated links from technology page

### DIFF
--- a/algosone-ai/pages/technology/algosone.ai/technology/index.html
+++ b/algosone-ai/pages/technology/algosone.ai/technology/index.html
@@ -198,10 +198,6 @@
 <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-626">
 <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/affiliates/">Affiliates</a><span class="description">Become an affiliate and showcase our benefits.</span>
 </li>
-<li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-627">
-<a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/influencers/">Influencers</a><span class="description">Introduce your followers to a great
-                          opportunity.</span>
-</li>
 <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-289">
 <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/faq/">FAQ</a><span class="description">Have a question? We’ve got the answer.</span>
 </li>
@@ -290,9 +286,6 @@
 </li>
 <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-626" id="menu-item-626">
 <a href="https://algosone.ai/affiliates/" itemprop="url">Affiliates</a>
-</li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-627" id="menu-item-627">
-<a href="https://algosone.ai/influencers/" itemprop="url">Influencers</a>
 </li>
 <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289" id="menu-item-289">
 <a href="https://algosone.ai/faq/" itemprop="url">FAQ</a>
@@ -600,9 +593,6 @@
 <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-666" id="menu-item-666">
 <a href="https://algosone.ai/affiliates/" itemprop="url">Affiliates</a>
 </li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-667" id="menu-item-667">
-<a href="https://algosone.ai/influencers/" itemprop="url">Influencers</a>
-</li>
 <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9916" id="menu-item-9916">
 <a href="https://algosone.ai/trust-center/" itemprop="url">Trust center</a>
 </li>
@@ -625,20 +615,8 @@
 <div>
 <div class="f-head text-center">Let Us Help You</div>
 <ul class="menu" id="menu-menu-footer-3">
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-528" id="menu-item-528">
-<a href="https://algosone.ai/terms/" itemprop="url">Terms &amp; Conditions</a>
-</li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-481" id="menu-item-481">
-<a href="https://algosone.ai/aml-policy/" itemprop="url">AML Policy</a>
-</li>
 <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy menu-item-485" id="menu-item-485">
 <a href="https://algosone.ai/privacy-policy/" itemprop="url" rel="privacy-policy">Privacy Policy</a>
-</li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-483" id="menu-item-483">
-<a href="https://algosone.ai/cookie-policy/" itemprop="url">Cookie Policy</a>
-</li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-484" id="menu-item-484">
-<a href="https://algosone.ai/sitemap/" itemprop="url">Sitemap</a>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
## Summary
- remove navigation link to Influencers page
- delete footer links to Terms & Conditions, AML policy, Cookie policy and Sitemap on the technology page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a78c6f38083209fbb596cc9684760