### PR TITLE
Remove outdated links on about page

### DIFF
--- a/algosone-ai/pages/about/algosone.ai/about/index.html
+++ b/algosone-ai/pages/about/algosone.ai/about/index.html
@@ -346,7 +346,6 @@
               </div>
               <div class="col-middle">
                 <div id="menu-header-1" class="menu">
-                  
                   <li
                     id="nav-menu-item-37"
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
@@ -357,7 +356,6 @@
                       >Technology</a
                     >
                   </li>
-                  
                   <li
                     id="nav-menu-item-486"
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
@@ -400,8 +398,6 @@
                           >See what makes us stand out from the crowd.</span
                         >
                       </li>
-                      
-                      
                       <li
                         id="nav-menu-item-626"
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
@@ -415,21 +411,6 @@
                         >
                       </li>
                       <li
-                        id="nav-menu-item-627"
-                        class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
-                      >
-                        <a
-                          href="https://algosone.ai/influencers/"
-                          class="magnetic-item-off menu-link sub-menu-link"
-                          >Influencers</a
-                        ><span class="description"
-                          >Introduce your followers to a great
-                          opportunity.</span
-                        >
-                      </li>
-                      
-                      
-                      <li
                         id="nav-menu-item-289"
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
@@ -441,8 +422,6 @@
                           >Have a question? We’ve got the answer.</span
                         >
                       </li>
-                      
-                      
                       <li
                         id="nav-menu-item-1480"
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
@@ -591,9 +570,6 @@
                     <div class="tt-ol-menu-inner tt-wrap">
                       <div class="tt-ol-menu-content">
                         <ul id="menu-header-2" class="tt-ol-menu-list">
-                          
-                              
-                              
                             </ul>
                           </li>
                           <li
@@ -606,7 +582,6 @@
                               >Technology</a
                             >
                           </li>
-                          
                           <li
                             id="menu-item-486"
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-486"
@@ -644,8 +619,6 @@
                                   >About</a
                                 >
                               </li>
-                              
-                              
                               <li
                                 id="menu-item-626"
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-626"
@@ -657,18 +630,6 @@
                                 >
                               </li>
                               <li
-                                id="menu-item-627"
-                                class="menu-item menu-item-type-post_type menu-item-object-page menu-item-627"
-                              >
-                                <a
-                                  href="https://algosone.ai/influencers/"
-                                  itemprop="url"
-                                  >Influencers</a
-                                >
-                              </li>
-                              
-                              
-                              <li
                                 id="menu-item-289"
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289"
                               >
@@ -678,8 +639,6 @@
                                   >FAQ</a
                                 >
                               </li>
-                              
-                              
                               <li
                                 id="menu-item-1480"
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1480"
@@ -1243,7 +1202,6 @@
                     <div>
                       <div class="f-head text-center">Get to Know Us</div>
                       <ul id="menu-menu-footer-1" class="menu">
-                        
                         <li
                           id="menu-item-1590"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590"
@@ -1254,8 +1212,6 @@
                             >AI Crypto Trading</a
                           >
                         </li>
-                        
-                        
                         <li
                           id="menu-item-18"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"
@@ -1266,7 +1222,6 @@
                             >Technology</a
                           >
                         </li>
-                        
                         <li
                           id="menu-item-499"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-499"
@@ -1295,17 +1250,7 @@
                             >Affiliates</a
                           >
                         </li>
-                        <li
-                          id="menu-item-667"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-667"
-                        >
-                          <a
-                            href="https://algosone.ai/influencers/"
-                            itemprop="url"
-                            >Influencers</a
-                          >
-                        </li>
-                        <li
+                                                <li
                           id="menu-item-9916"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9916"
                         >
@@ -1331,12 +1276,6 @@
                             >About</a
                           >
                         </li>
-                        
-                        
-                        
-                        
-                        
-                        
                         <li
                           id="menu-item-502"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-502"
@@ -1353,32 +1292,12 @@
                             >AlgosOne Reviews</a
                           >
                         </li>
-                        
-                        
                       </ul>
                     </div>
                     <div>
                       <div class="f-head text-center">Let Us Help You</div>
                       <ul id="menu-menu-footer-3" class="menu">
-                        <li
-                          id="menu-item-528"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-528"
-                        >
-                          <a href="https://algosone.ai/terms/" itemprop="url"
-                            >Terms & Conditions</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-481"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-481"
-                        >
-                          <a
-                            href="https://algosone.ai/aml-policy/"
-                            itemprop="url"
-                            >AML Policy</a
-                          >
-                        </li>
-                        <li
+                                                                        <li
                           id="menu-item-485"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy menu-item-485"
                         >
@@ -1389,26 +1308,7 @@
                             >Privacy Policy</a
                           >
                         </li>
-                        
-                        <li
-                          id="menu-item-483"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-483"
-                        >
-                          <a
-                            href="https://algosone.ai/cookie-policy/"
-                            itemprop="url"
-                            >Cookie Policy</a
-                          >
-                        </li>
-                        <li
-                          id="menu-item-484"
-                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-484"
-                        >
-                          <a href="https://algosone.ai/sitemap/" itemprop="url"
-                            >Sitemap</a
-                          >
-                        </li>
-                      </ul>
+                                                                      </ul>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove references to deleted pages on `about/index.html`
- clean up whitespace after deleting those menu links

## Testing
- `grep -n "influencers" algosone-ai/pages/about/algosone.ai/about/index.html`
- `grep -n "aml-policy" algosone-ai/pages/about/algosone.ai/about/index.html`
- `grep -n "cookie-policy" algosone-ai/pages/about/algosone.ai/about/index.html`
- `grep -n "sitemap" algosone-ai/pages/about/algosone.ai/about/index.html`


------
https://chatgpt.com/codex/tasks/task_e_685a812c2e1c83208c37645e75248fea