### PR TITLE
Update profitability page branding

### DIFF
--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -39,10 +39,10 @@
       href="../assets/cache/autoptimize/css/autoptimize_8529b7187418b28dc076054cf9362934.css"
       rel="stylesheet"
     />
-    <title>Profitability of Using AI Trading Tools — AlgosOne</title>
+    <title>Profitability of Using AI Trading Tools — Aqronix</title>
     <meta
       name="description"
-      content="Profitability of using AlgosOne AI trading tools. ⚡️ AlgosOne™⚡️ How much profit can you make with AlgosOne AI trading tools? 💰 Find out now ⏩."
+      content="Profitability of using Aqronix AI trading tools. ⚡️ Aqronix™⚡️ How much profit can you make with Aqronix AI trading tools? 💰 Find out now ⏩."
     />
     <link rel="canonical" href="https://algosone.ai/profitability/" />
     <meta property="og:locale" content="en_US" />
@@ -50,10 +50,10 @@
     <meta property="og:title" content="Achieve Your Profit Potential" />
     <meta
       property="og:description"
-      content="Profitability of using AlgosOne AI trading tools. ⚡️ AlgosOne™⚡️ How much profit can you make with AlgosOne AI trading tools? 💰 Find out now ⏩."
+      content="Profitability of using Aqronix AI trading tools. ⚡️ Aqronix™⚡️ How much profit can you make with Aqronix AI trading tools? 💰 Find out now ⏩."
     />
     <meta property="og:url" content="https://algosone.ai/profitability/" />
-    <meta property="og:site_name" content="AlgosOne" />
+    <meta property="og:site_name" content="Aqronix" />
     <meta
       property="article:modified_time"
       content="2024-07-09T08:17:35+00:00"
@@ -67,11 +67,11 @@
             "@type": "WebPage",
             "@id": "https://algosone.ai/profitability/",
             "url": "https://algosone.ai/profitability/",
-            "name": "Profitability of Using AI Trading Tools — AlgosOne",
+            "name": "Profitability of Using AI Trading Tools — Aqronix",
             "isPartOf": { "@id": "https://algosone.ai/#website" },
             "datePublished": "2023-05-11T12:28:12+00:00",
             "dateModified": "2024-07-09T08:17:35+00:00",
-            "description": "Profitability of using AlgosOne AI trading tools. ⚡️ AlgosOne™⚡️ How much profit can you make with AlgosOne AI trading tools? 💰 Find out now ⏩.",
+            "description": "Profitability of using Aqronix AI trading tools. ⚡️ Aqronix™⚡️ How much profit can you make with Aqronix AI trading tools? 💰 Find out now ⏩.",
             "breadcrumb": {
               "@id": "https://algosone.ai/profitability/#breadcrumb"
             },
@@ -104,7 +104,7 @@
             "@type": "WebSite",
             "@id": "https://algosone.ai/#website",
             "url": "https://algosone.ai/",
-            "name": "AlgosOne",
+            "name": "Aqronix",
             "description": "AI Trading Solution",
             "publisher": { "@id": "https://algosone.ai/#organization" },
             "potentialAction": [
@@ -122,7 +122,7 @@
           {
             "@type": "Organization",
             "@id": "https://algosone.ai/#organization",
-            "name": "AlgosOne",
+            "name": "Aqronix",
             "url": "https://algosone.ai/",
             "logo": {
               "@type": "ImageObject",
@@ -132,7 +132,7 @@
               "contentUrl": "https://algosone.ai/assets/uploads/2023/06/logo-1.png",
               "width": 44,
               "height": 44,
-              "caption": "AlgosOne"
+              "caption": "Aqronix"
             },
             "image": { "@id": "https://algosone.ai/#/schema/logo/image/" }
           }
@@ -143,7 +143,7 @@
     <link
       rel="alternate"
       type="application/rss+xml"
-      title="AlgosOne � Feed"
+      title="Aqronix � Feed"
       href="https://algosone.ai/feed/"
     />
     <script
@@ -334,8 +334,8 @@
                       data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[1][self::HEADER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]"
                       src="../assets/themes/common/assets/images/logo.svg"
                       class="tt-logo-light magnetic-item cursor-alter"
-                      alt="algosone uk"
-                      title="AlgosOne"
+                      alt="aqronix uk"
+                      title="Aqronix"
                     />
                     <img
                       data-od-added-fetchpriority=""
@@ -343,10 +343,10 @@
                       fetchpriority="low"
                       src="../assets/themes/common/assets/images/logo.svg"
                       class="tt-logo-dark magnetic-item cursor-alter"
-                      alt="algosone uk"
-                      title="AlgosOne"
+                      alt="aqronix uk"
+                      title="Aqronix"
                     />
-                    <span class="text">AlgosOne</span>
+                    <span class="text">Aqronix</span>
                   </a>
                 </div>
               </div>
@@ -445,12 +445,12 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          title="AlgosOne clients reviews"
+                          title="Aqronix clients reviews"
                           href="https://algosone.ai/reviews/"
                           class="magnetic-item-off menu-link sub-menu-link"
-                          >AlgosOne Reviews</a
+                          >Aqronix Reviews</a
                         ><span class="description"
-                          >AlgosOne clients reviews</span
+                          >Aqronix clients reviews</span
                         >
                       </li>
                       <li
@@ -458,12 +458,12 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          title="AlgosOne is a licensed financial services provider"
+                          title="Aqronix is a licensed financial services provider"
                           href="https://algosone.ai/trust-center/"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Trust center</a
                         ><span class="description"
-                          >AlgosOne is a licensed financial services
+                          >Aqronix is a licensed financial services
                           provider</span
                         >
                       </li>
@@ -581,7 +581,7 @@
                   </div>
                 </div>
                 <nav class="tt-overlay-menu tt-ol-menu-count">
-                  <div class="tt-ol-menu-ghost">AlgosOne</div>
+                  <div class="tt-ol-menu-ghost">Aqronix</div>
                   <div class="tt-ol-menu-holder">
                     <div class="tt-ol-menu-inner tt-wrap">
                       <div class="tt-ol-menu-content">
@@ -669,9 +669,9 @@
                               >
                                 <a
                                   href="https://algosone.ai/reviews/"
-                                  title="AlgosOne clients reviews"
+                                  title="Aqronix clients reviews"
                                   itemprop="url"
-                                  >AlgosOne Reviews</a
+                                  >Aqronix Reviews</a
                                 >
                               </li>
                               <li
@@ -680,7 +680,7 @@
                               >
                                 <a
                                   href="https://algosone.ai/trust-center/"
-                                  title="AlgosOne is a licensed financial services provider"
+                                  title="Aqronix is a licensed financial services provider"
                                   itemprop="url"
                                   >Trust center</a
                                 >
@@ -796,12 +796,12 @@
                             <div class="icon green"></div>
                             <div class="title">Compensation</div>
                             At the higher tiers, compensation is offered for
-                            failed trades, drawn from the AlgosOne reserve fund.
+                            failed trades, drawn from the Aqronix reserve fund.
                             A percentage of the sum invested in the trade is
                             returned to your balance. The higher the trading
                             tier, the higher the compensation percentage.<br /><br /><strong
                               >Example</strong
-                            >: AlgosOne opens a $1,000, trade, which is
+                            >: Aqronix opens a $1,000, trade, which is
                             unsuccessful, resulting in a loss of $100. If your
                             compensation rate is 100%, the system will
                             compensate you for the full amount of the loss. If
@@ -815,10 +815,10 @@
                           <div class="wrap">
                             <div class="icon yellow"></div>
                             <div class="title">Commissions</div>
-                            AlgosOne charges no transaction fees but there is a
+                            Aqronix charges no transaction fees but there is a
                             commission of up to 25% on every profitable trade.
                             This percentage will be lower at the higher trading
-                            tiers.<br /><br />For example, if AlgosOne opens a
+                            tiers.<br /><br />For example, if Aqronix opens a
                             position for $1,000, which generates a $200 pro fit,
                             your balance is credited with $150, while $50, (25%
                             of the $200 profit) is charged in commission.<br /><br />50%
@@ -837,7 +837,7 @@
                                 partial, or full compensation for losing trades
                               </li>
                               <li>
-                                monthly dividends to AlgosOne shareholders
+                                monthly dividends to Aqronix shareholders
                               </li>
                             </ul>
                             <br />The current reserve amount is always viewable
@@ -849,7 +849,7 @@
                           <div class="wrap">
                             <div class="icon red"></div>
                             <div class="title">Compounding</div>
-                            AlgosOne offers compounding to all users, at every
+                            Aqronix offers compounding to all users, at every
                             trading tier, who transfer funds to a trading
                             balance.
                           </div>
@@ -879,7 +879,7 @@
                           </h2>
                         </div>
                         <p class="anim-fadeinup">
-                          Earn the maximum from your capital with an AlgosOne
+                          Earn the maximum from your capital with an Aqronix
                           investment plan. Capital is initially invested for 24
                           months. Any additional investments made within that
                           calendar year are added to the same 24-month plan.
@@ -944,7 +944,7 @@
                         class="tt-logo-light magnetic-item cursor-alter"
                         alt="Logo"
                       />
-                      <span class="text">AlgosOne</span>
+                      <span class="text">Aqronix</span>
                     </a>
                     <div class="social-menu">
                       <a
@@ -1159,7 +1159,7 @@
                       </div>
                     </div>
                     <div class="copyr">
-                      © 2025 AlgosOne.ai All rights reserved.
+                      © 2025 Aqronix.ai All rights reserved.
                     </div>
                   </div>
                   <div class="col-right">
@@ -1241,7 +1241,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3017"
                         >
                           <a href="https://algosone.ai/reviews/" itemprop="url"
-                            >AlgosOne Reviews</a
+                            >Aqronix Reviews</a
                           >
                         </li>
                       </ul>
@@ -1266,7 +1266,7 @@
                 </div>
                 <div class="row-1">
                   <div class="reqfoot">
-                    AlgosOne.ai is operated by White Mint Financial Company
+                    Aqronix.ai is operated by White Mint Financial Company
                     s.r.o., a registered company in the Czech Republic
                     (registration number 17260884). White Mint Financial Company
                     s.r.o. is regulated by FAU in the Czech Republic and holds


### PR DESCRIPTION
## Summary
- update displayed name from AlgosOne to Aqronix on profitability page

## Testing
- `grep -n "AlgosOne" algosone-ai/pages/profitability/algosone.ai/profitability/index.html`


------
https://chatgpt.com/codex/tasks/task_e_685a959b6be48320926ffa7edf2d9cb4