### PR TITLE
Fix AI Crypto Trading link path

### DIFF
--- a/algosone-ai/pages/home/algosone.ai/index.html
+++ b/algosone-ai/pages/home/algosone.ai/index.html
@@ -334,7 +334,7 @@
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
                   >
                     <a
-                      href="../ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
+                      href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
                       class="magnetic-item-off menu-link main-menu-link"
                       >AI Crypto Trading</a
                     >
@@ -344,7 +344,7 @@
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
                   >
                     <a
-                      href="../technology/algosone.ai/technology/index.html"
+                      href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                       class="magnetic-item-off menu-link main-menu-link"
                       >Technology</a
                     >
@@ -354,7 +354,7 @@
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
                   >
                     <a
-                      href="../profitability/algosone.ai/profitability/index.html"
+                      href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                       class="magnetic-item-off menu-link main-menu-link"
                       >Profitability</a
                     >
@@ -372,7 +372,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="../markets/algosone.ai/markets/index.html"
+                          href="/algosone-ai/pages/markets/algosone.ai/markets/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Markets</a
                         ><span class="description"
@@ -384,7 +384,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="../about/algosone.ai/about/index.html"
+                          href="/algosone-ai/pages/about/algosone.ai/about/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >About</a
                         ><span class="description"
@@ -396,7 +396,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="../affiliates/algosone.ai/affiliates/index.html"
+                          href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Affiliates</a
                         ><span class="description"
@@ -408,7 +408,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="../faq/algosone.ai/faq/index.html"
+                          href="/algosone-ai/pages/faq/algosone.ai/faq/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >FAQ</a
                         ><span class="description"
@@ -420,7 +420,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="../contact/algosone.ai/contact/index.html"
+                          href="/algosone-ai/pages/contact/algosone.ai/contact/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Contact Us</a
                         ><span class="description"
@@ -433,7 +433,7 @@
                       >
                         <a
                           title="Aqronix clients reviews"
-                          href="../reviews/algosone.ai/reviews/index.html"
+                          href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Aqronix Reviews</a
                         ><span class="description"
@@ -446,7 +446,7 @@
                       >
                         <a
                           title="Aqronix is a licensed financial services provider"
-                          href="../trust-center/algosone.ai/trust-center/index.html"
+                          href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Trust center</a
                         ><span class="description"
@@ -568,7 +568,7 @@
                               class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1584"
                             >
                               <a
-                                href="../ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
+                                href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
                                 itemprop="url"
                                 >AI Crypto Trading</a
                               >
@@ -578,7 +578,7 @@
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"
                           >
                             <a
-                              href="../technology/algosone.ai/technology/index.html"
+                              href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                               itemprop="url"
                               >Technology</a
                             >
@@ -588,7 +588,7 @@
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-486"
                           >
                             <a
-                              href="../profitability/algosone.ai/profitability/index.html"
+                              href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                               itemprop="url"
                               >Profitability</a
                             >
@@ -604,7 +604,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-488"
                               >
                                 <a
-                                  href="../markets/algosone.ai/markets/index.html"
+                                  href="/algosone-ai/pages/markets/algosone.ai/markets/index.html"
                                   itemprop="url"
                                   >Markets</a
                                 >
@@ -614,7 +614,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-38"
                               >
                                 <a
-                                  href="../about/algosone.ai/about/index.html"
+                                  href="/algosone-ai/pages/about/algosone.ai/about/index.html"
                                   itemprop="url"
                                   >About</a
                                 >
@@ -624,7 +624,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-626"
                               >
                                 <a
-                                  href="../affiliates/algosone.ai/affiliates/index.html"
+                                  href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                                   itemprop="url"
                                   >Affiliates</a
                                 >
@@ -634,7 +634,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289"
                               >
                                 <a
-                                  href="../faq/algosone.ai/faq/index.html"
+                                  href="/algosone-ai/pages/faq/algosone.ai/faq/index.html"
                                   itemprop="url"
                                   >FAQ</a
                                 >
@@ -644,7 +644,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1480"
                               >
                                 <a
-                                  href="../contact/algosone.ai/contact/index.html"
+                                  href="/algosone-ai/pages/contact/algosone.ai/contact/index.html"
                                   itemprop="url"
                                   >Contact Us</a
                                 >
@@ -654,7 +654,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3027"
                               >
                                 <a
-                                  href="../reviews/algosone.ai/reviews/index.html"
+                                  href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html"
                                   title="Aqronix clients reviews"
                                   itemprop="url"
                                   >Aqronix Reviews</a
@@ -665,7 +665,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9915"
                               >
                                 <a
-                                  href="../trust-center/algosone.ai/trust-center/index.html"
+                                  href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                                   title="Aqronix is a licensed financial services provider"
                                   itemprop="url"
                                   >Trust center</a
@@ -2578,7 +2578,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590"
                         >
                           <a
-                            href="../ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
+                            href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
                             itemprop="url"
                             >AI Crypto Trading</a
                           >
@@ -2588,7 +2588,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"
                         >
                           <a
-                            href="../technology/algosone.ai/technology/index.html"
+                            href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                             itemprop="url"
                             >Technology</a
                           >
@@ -2597,7 +2597,7 @@
                           id="menu-item-499"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-499"
                         >
-                          <a href="../markets/algosone.ai/markets/index.html" itemprop="url"
+                          <a href="/algosone-ai/pages/markets/algosone.ai/markets/index.html" itemprop="url"
                             >Markets</a
                           >
                         </li>
@@ -2606,7 +2606,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-498"
                         >
                           <a
-                            href="../profitability/algosone.ai/profitability/index.html"
+                            href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                             itemprop="url"
                             >Profitability</a
                           >
@@ -2616,7 +2616,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-666"
                         >
                           <a
-                            href="../affiliates/algosone.ai/affiliates/index.html"
+                            href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                             itemprop="url"
                             >Affiliates</a
                           >
@@ -2626,7 +2626,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9916"
                         >
                           <a
-                            href="../trust-center/algosone.ai/trust-center/index.html"
+                            href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                             itemprop="url"
                             >Trust center</a
                           >
@@ -2640,7 +2640,7 @@
                           id="menu-item-503"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-503"
                         >
-                          <a href="../about/algosone.ai/about/index.html" itemprop="url"
+                          <a href="/algosone-ai/pages/about/algosone.ai/about/index.html" itemprop="url"
                             >About</a
                           >
                         </li>
@@ -2648,7 +2648,7 @@
                           id="menu-item-502"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-502"
                         >
-                          <a href="../faq/algosone.ai/faq/index.html" itemprop="url"
+                          <a href="/algosone-ai/pages/faq/algosone.ai/faq/index.html" itemprop="url"
                             >FAQ</a
                           >
                         </li>
@@ -2656,7 +2656,7 @@
                           id="menu-item-3017"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3017"
                         >
-                          <a href="../reviews/algosone.ai/reviews/index.html" itemprop="url"
+                          <a href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" itemprop="url"
                             >Aqronix Reviews</a
                           >
                         </li>


### PR DESCRIPTION
## Summary
- fix AI Crypto Trading links on the home page
- update all internal links to absolute paths

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685be7e1808c83209ba89063245b615f