### PR TITLE
Update ai crypto trading links

### DIFF
--- a/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
+++ b/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
@@ -17,17 +17,17 @@
    AI Crypto Trading (Artificial Intelligence for Cryptocurrency Trading) — Aqronix
   </title>
   <meta content="AI crypto trading (artificial intelligence for cryptocurrency trading). ⚡️ Aqronix™⚡️ AI crypto trading apps, bots. 💰 Make money with Aqronix right now ⏩!" name="description"/>
-  <link href="https://aqronix.ai/ai-crypto-trading/" rel="canonical"/>
+  <link href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" rel="canonical"/>
   <meta content="en_US" property="og:locale"/>
   <meta content="article" property="og:type"/>
   <meta content="AI Crypto Trading" property="og:title"/>
   <meta content="AI crypto trading (artificial intelligence for cryptocurrency trading). ⚡️ Aqronix™⚡️ AI crypto trading apps, bots. 💰 Make money with Aqronix right now ⏩!" property="og:description"/>
-  <meta content="https://aqronix.ai/ai-crypto-trading/" property="og:url"/>
+  <meta content="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" property="og:url"/>
   <meta content="Aqronix" property="og:site_name"/>
   <meta content="2025-04-25T14:27:08+00:00" property="article:modified_time"/>
   <meta content="summary_large_image" name="twitter:card"/>
   <script class="yoast-schema-graph" type="application/ld+json">
-   {"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://aqronix.ai/ai-crypto-trading/","url":"https://aqronix.ai/ai-crypto-trading/","name":"Trading di criptovalute IA (intelligenza artificiale per il trading di criptovalute) — Aqronix","isPartOf":{"@id":"https://aqronix.ai/#website"},"datePublished":"2023-11-28T20:49:33+00:00","dateModified":"2025-04-25T14:27:08+00:00","description":"Trading di criptovalute AI (intelligenza artificiale per il trading di criptovalute). ⚡️ Aqronix™⚡️ App e robot per il trading di criptovalute AI. 💰 Guadagna subito con Aqronix ⏩!","breadcrumb":{"@id":"https://aqronix.ai/ai-crypto-trading/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://aqronix.ai/ai-crypto-trading/"]}]},{"@type":"BreadcrumbList","@id":"https://aqronix.ai/ai-crypto-trading/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://aqronix.ai/"},{"@type":"ListItem","position":2,"name":"AI Crypto Trading"}]},{"@type":"WebSite","@id":"https://aqronix.ai/#website","url":"https://aqronix.ai/","name":"Aqronix","description":"AI Trading Solution","publisher":{"@id":"https://aqronix.ai/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://aqronix.ai/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https://aqronix.ai/#organization","name":"Aqronix","url":"https://aqronix.ai/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://aqronix.ai/#/schema/logo/image/","url":"https://aqronix.ai/assets/uploads/2023/06/logo-1.png","contentUrl":"https://aqronix.ai/assets/uploads/2023/06/logo-1.png","width":44,"height":44,"caption":"Aqronix"},"image":{"@id":"https://aqronix.ai/#/schema/logo/image/"}}]}
+   {"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html","url":"/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html","name":"Trading di criptovalute IA (intelligenza artificiale per il trading di criptovalute) — Aqronix","isPartOf":{"@id":"https://aqronix.ai/#website"},"datePublished":"2023-11-28T20:49:33+00:00","dateModified":"2025-04-25T14:27:08+00:00","description":"Trading di criptovalute AI (intelligenza artificiale per il trading di criptovalute). ⚡️ Aqronix™⚡️ App e robot per il trading di criptovalute AI. 💰 Guadagna subito con Aqronix ⏩!","breadcrumb":{"@id":"/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"]}]},{"@type":"BreadcrumbList","@id":"/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://aqronix.ai/"},{"@type":"ListItem","position":2,"name":"AI Crypto Trading"}]},{"@type":"WebSite","@id":"https://aqronix.ai/#website","url":"https://aqronix.ai/","name":"Aqronix","description":"AI Trading Solution","publisher":{"@id":"https://aqronix.ai/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://aqronix.ai/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https://aqronix.ai/#organization","name":"Aqronix","url":"https://aqronix.ai/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://aqronix.ai/#/schema/logo/image/","url":"https://aqronix.ai/assets/uploads/2023/06/logo-1.png","contentUrl":"https://aqronix.ai/assets/uploads/2023/06/logo-1.png","width":44,"height":44,"caption":"Aqronix"},"image":{"@id":"https://aqronix.ai/#/schema/logo/image/"}}]}
   </script>
   <link href="//www.googletagmanager.com" rel="dns-prefetch"/>
   <link href="https://aqronix.ai/feed/" rel="alternate" title="Aqronix � Feed" type="application/rss+xml"/>
@@ -76,11 +76,11 @@ gtag("config", "GT-WR9QBQT");
   <meta content="image-prioritizer 1.0.0-beta2" name="generator"/>
   <script defer="" src="data:text/javascript;base64,KGZ1bmN0aW9uKHcsZCxzLGwsaSl7d1tsXT13W2xdfHxbXTt3W2xdLnB1c2goeydndG0uc3RhcnQnOm5ldyBEYXRlKCkuZ2V0VGltZSgpLGV2ZW50OidndG0uanMnfSk7dmFyIGY9ZC5nZXRFbGVtZW50c0J5VGFnTmFtZShzKVswXSxqPWQuY3JlYXRlRWxlbWVudChzKSxkbD1sIT0nZGF0YUxheWVyJz8nJmw9JytsOicnO2ouYXN5bmM9dHJ1ZTtqLnNyYz0naHR0cHM6Ly93d3cuZ29vZ2xldGFnbWFuYWdlci5jb20vZ3RtLmpzP2lkPScraStkbDtmLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKGosZik7fSkod2luZG93LGRvY3VtZW50LCdzY3JpcHQnLCdkYXRhTGF5ZXInLCdHVE0tTVZIU0hMRjgnKTs=">
   </script>
-  <link href="https://aqronix.ai/ai-crypto-trading/" hreflang="x-default" rel="alternate"/>
-  <link href="https://aqronix.ai/es/ai-crypto-trading/" hreflang="es-ES" rel="alternate"/>
-  <link href="https://aqronix.ai/de/ai-crypto-trading/" hreflang="de-DE" rel="alternate"/>
-  <link href="https://aqronix.ai/it/ai-crypto-trading/" hreflang="it-IT" rel="alternate"/>
-  <link href="https://aqronix.ai/fr/ai-crypto-trading/" hreflang="fr-FR" rel="alternate"/>
+  <link href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" hreflang="x-default" rel="alternate"/>
+  <link href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" hreflang="es-ES" rel="alternate"/>
+  <link href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" hreflang="de-DE" rel="alternate"/>
+  <link href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" hreflang="it-IT" rel="alternate"/>
+  <link href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" hreflang="fr-FR" rel="alternate"/>
   <script defer="" src="data:text/javascript;base64,CiAgICAgICAgbGV0IENVUlJFTlRfU0lURSA9ICdodHRwczovL2FsZ29zb25lLmFpJzsKICAgICAgICBsZXQgX2hoID0gMDsKICAgIA==">
   </script>
   <script defer="" src="../../widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" type="text/javascript">
@@ -135,12 +135,12 @@ gtag("config", "GT-WR9QBQT");
        <div class="col-middle">
         <div class="menu" id="menu-header-1">
          <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-37">
-          <a class="magnetic-item-off menu-link main-menu-link" href="https://aqronix.ai/technology/">
+          <a class="magnetic-item-off menu-link main-menu-link" href="/algosone-ai/pages/technology/algosone.ai/technology/index.html">
            Technology
           </a>
          </li>
          <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-486">
-          <a class="magnetic-item-off menu-link main-menu-link" href="https://aqronix.ai/profitability/">
+          <a class="magnetic-item-off menu-link main-menu-link" href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html">
            Profitability
           </a>
          </li>
@@ -150,7 +150,7 @@ gtag("config", "GT-WR9QBQT");
           </a>
           <ul class="sub-menu menu-odd menu-depth-1">
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-488">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://aqronix.ai/markets/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/markets/algosone.ai/markets/index.html">
              Markets
             </a>
             <span class="description">
@@ -158,7 +158,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-38">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://aqronix.ai/about/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/about/algosone.ai/about/index.html">
              About
             </a>
             <span class="description">
@@ -166,7 +166,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-626">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://aqronix.ai/affiliates/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html">
              Affiliates
             </a>
             <span class="description">
@@ -174,7 +174,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-289">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://aqronix.ai/faq/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/faq/algosone.ai/faq/index.html">
              FAQ
             </a>
             <span class="description">
@@ -182,7 +182,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1480">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://aqronix.ai/contact/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/contact/algosone.ai/contact/index.html">
              Contact Us
             </a>
             <span class="description">
@@ -190,7 +190,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-3027">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://aqronix.ai/reviews/" title="Aqronix clients reviews">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" title="Aqronix clients reviews">
              Aqronix Reviews
             </a>
             <span class="description">
@@ -198,7 +198,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-9915">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://aqronix.ai/trust-center/" title="Aqronix is a licensed financial services provider">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html" title="Aqronix is a licensed financial services provider">
              Trust center
             </a>
             <span class="description">
@@ -232,35 +232,35 @@ gtag("config", "GT-WR9QBQT");
            </a>
           </li>
           <li class="menu-item menu-item-type-custom menu-item-object-custom menu_item_wpglobus_menu_switch wpglobus-selector-link wpglobus-current-language menu-item-9999999999" id="menu-item-9999999999">
-           <a href="https://aqronix.ai/ai-crypto-trading/" itemprop="url">
+           <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">
             <span class="wpglobus_flag wpglobus_language_name wpglobus_flag_en">
              en
             </span>
            </a>
            <ul class="sub-menu">
             <li class="menu-item menu-item-type-custom menu-item-object-custom sub_menu_item_wpglobus_menu_switch wpglobus-selector-link menu-item-wpglobus_menu_switch_es" id="menu-item-wpglobus_menu_switch_es">
-             <a href="https://aqronix.ai/es/ai-crypto-trading/" itemprop="url">
+             <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">
               <span class="wpglobus_flag wpglobus_language_name wpglobus_flag_es">
                es
               </span>
              </a>
             </li>
             <li class="menu-item menu-item-type-custom menu-item-object-custom sub_menu_item_wpglobus_menu_switch wpglobus-selector-link menu-item-wpglobus_menu_switch_de" id="menu-item-wpglobus_menu_switch_de">
-             <a href="https://aqronix.ai/de/ai-crypto-trading/" itemprop="url">
+             <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">
               <span class="wpglobus_flag wpglobus_language_name wpglobus_flag_de">
                de
               </span>
              </a>
             </li>
             <li class="menu-item menu-item-type-custom menu-item-object-custom sub_menu_item_wpglobus_menu_switch wpglobus-selector-link menu-item-wpglobus_menu_switch_it" id="menu-item-wpglobus_menu_switch_it">
-             <a href="https://aqronix.ai/it/ai-crypto-trading/" itemprop="url">
+             <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">
               <span class="wpglobus_flag wpglobus_language_name wpglobus_flag_it">
                it
               </span>
              </a>
             </li>
             <li class="menu-item menu-item-type-custom menu-item-object-custom sub_menu_item_wpglobus_menu_switch wpglobus-selector-link menu-item-wpglobus_menu_switch_fr" id="menu-item-wpglobus_menu_switch_fr">
-             <a href="https://aqronix.ai/fr/ai-crypto-trading/" itemprop="url">
+             <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">
               <span class="wpglobus_flag wpglobus_language_name wpglobus_flag_fr">
                fr
               </span>
@@ -299,12 +299,12 @@ gtag("config", "GT-WR9QBQT");
            <div class="tt-ol-menu-content">
             <ul class="tt-ol-menu-list" id="menu-header-2">
              <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37" id="menu-item-37">
-              <a href="https://aqronix.ai/technology/" itemprop="url">
+              <a href="/algosone-ai/pages/technology/algosone.ai/technology/index.html" itemprop="url">
                Technology
               </a>
              </li>
              <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-486" id="menu-item-486">
-              <a href="https://aqronix.ai/profitability/" itemprop="url">
+              <a href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html" itemprop="url">
                Profitability
               </a>
              </li>
@@ -314,37 +314,37 @@ gtag("config", "GT-WR9QBQT");
               </a>
               <ul class="sub-menu">
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-488" id="menu-item-488">
-                <a href="https://aqronix.ai/markets/" itemprop="url">
+                <a href="/algosone-ai/pages/markets/algosone.ai/markets/index.html" itemprop="url">
                  Markets
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-38" id="menu-item-38">
-                <a href="https://aqronix.ai/about/" itemprop="url">
+                <a href="/algosone-ai/pages/about/algosone.ai/about/index.html" itemprop="url">
                  About
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-626" id="menu-item-626">
-                <a href="https://aqronix.ai/affiliates/" itemprop="url">
+                <a href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html" itemprop="url">
                  Affiliates
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289" id="menu-item-289">
-                <a href="https://aqronix.ai/faq/" itemprop="url">
+                <a href="/algosone-ai/pages/faq/algosone.ai/faq/index.html" itemprop="url">
                  FAQ
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1480" id="menu-item-1480">
-                <a href="https://aqronix.ai/contact/" itemprop="url">
+                <a href="/algosone-ai/pages/contact/algosone.ai/contact/index.html" itemprop="url">
                  Contact Us
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3027" id="menu-item-3027">
-                <a href="https://aqronix.ai/reviews/" itemprop="url" title="Aqronix clients reviews">
+                <a href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" itemprop="url" title="Aqronix clients reviews">
                  Aqronix Reviews
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9915" id="menu-item-9915">
-                <a href="https://aqronix.ai/trust-center/" itemprop="url" title="Aqronix is a licensed financial services provider">
+                <a href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html" itemprop="url" title="Aqronix is a licensed financial services provider">
                  Trust center
                 </a>
                </li>
@@ -765,32 +765,32 @@ gtag("config", "GT-WR9QBQT");
            </div>
            <ul class="menu" id="menu-menu-footer-1">
             <li class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-1575 current_page_item menu-item-1590" id="menu-item-1590">
-             <a aria-current="page" href="https://aqronix.ai/ai-crypto-trading/" itemprop="url">
+             <a aria-current="page" href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">
               AI Crypto Trading
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18" id="menu-item-18">
-             <a href="https://aqronix.ai/technology/" itemprop="url">
+             <a href="/algosone-ai/pages/technology/algosone.ai/technology/index.html" itemprop="url">
               Technology
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-499" id="menu-item-499">
-             <a href="https://aqronix.ai/markets/" itemprop="url">
+             <a href="/algosone-ai/pages/markets/algosone.ai/markets/index.html" itemprop="url">
               Markets
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-498" id="menu-item-498">
-             <a href="https://aqronix.ai/profitability/" itemprop="url">
+             <a href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html" itemprop="url">
               Profitability
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-666" id="menu-item-666">
-             <a href="https://aqronix.ai/affiliates/" itemprop="url">
+             <a href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html" itemprop="url">
               Affiliates
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9916" id="menu-item-9916">
-             <a href="https://aqronix.ai/trust-center/" itemprop="url">
+             <a href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html" itemprop="url">
               Trust center
              </a>
             </li>
@@ -802,17 +802,17 @@ gtag("config", "GT-WR9QBQT");
            </div>
            <ul class="menu" id="menu-menu-footer-2">
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-503" id="menu-item-503">
-             <a href="https://aqronix.ai/about/" itemprop="url">
+             <a href="/algosone-ai/pages/about/algosone.ai/about/index.html" itemprop="url">
               About
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-502" id="menu-item-502">
-             <a href="https://aqronix.ai/faq/" itemprop="url">
+             <a href="/algosone-ai/pages/faq/algosone.ai/faq/index.html" itemprop="url">
               FAQ
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3017" id="menu-item-3017">
-             <a href="https://aqronix.ai/reviews/" itemprop="url">
+             <a href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" itemprop="url">
               Aqronix Reviews
              </a>
             </li>


### PR DESCRIPTION
## Summary
- update canonical and og:url links on AI crypto trading page
- switch navigation links from the aqronix.ai domain to local snapshot paths
- keep privacy policy link pointing to the live site

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bea9a989c8320986921d3a845a961