### PR TITLE
Fix profitability links

### DIFF
--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -44,7 +44,7 @@
       name="description"
       content="Profitability of using Aqronix AI trading tools. ⚡️ Aqronix™⚡️ How much profit can you make with Aqronix AI trading tools? 💰 Find out now ⏩."
     />
-    <link rel="canonical" href="https://algosone.ai/profitability/" />
+    <link rel="canonical" href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="Achieve Your Profit Potential" />
@@ -52,7 +52,7 @@
       property="og:description"
       content="Profitability of using Aqronix AI trading tools. ⚡️ Aqronix™⚡️ How much profit can you make with Aqronix AI trading tools? 💰 Find out now ⏩."
     />
-    <meta property="og:url" content="https://algosone.ai/profitability/" />
+    <meta property="og:url" content="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html" />
     <meta property="og:site_name" content="Aqronix" />
     <meta
       property="article:modified_time"
@@ -65,27 +65,27 @@
         "@graph": [
           {
             "@type": "WebPage",
-            "@id": "https://algosone.ai/profitability/",
-            "url": "https://algosone.ai/profitability/",
+            "@id": "/algosone-ai/pages/profitability/algosone.ai/profitability/index.html",
+            "url": "/algosone-ai/pages/profitability/algosone.ai/profitability/index.html",
             "name": "Profitability of Using AI Trading Tools — Aqronix",
             "isPartOf": { "@id": "https://algosone.ai/#website" },
             "datePublished": "2023-05-11T12:28:12+00:00",
             "dateModified": "2024-07-09T08:17:35+00:00",
             "description": "Profitability of using Aqronix AI trading tools. ⚡️ Aqronix™⚡️ How much profit can you make with Aqronix AI trading tools? 💰 Find out now ⏩.",
             "breadcrumb": {
-              "@id": "https://algosone.ai/profitability/#breadcrumb"
+              "@id": "/algosone-ai/pages/profitability/algosone.ai/profitability/index.html#breadcrumb"
             },
             "inLanguage": "en-US",
             "potentialAction": [
               {
                 "@type": "ReadAction",
-                "target": ["https://algosone.ai/profitability/"]
+                "target": ["/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"]
               }
             ]
           },
           {
             "@type": "BreadcrumbList",
-            "@id": "https://algosone.ai/profitability/#breadcrumb",
+            "@id": "/algosone-ai/pages/profitability/algosone.ai/profitability/index.html#breadcrumb",
             "itemListElement": [
               {
                 "@type": "ListItem",
@@ -262,7 +262,7 @@
     <link
       rel="alternate"
       hreflang="x-default"
-      href="https://algosone.ai/profitability/"
+      href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
     />
     <link
       rel="alternate"
@@ -357,7 +357,7 @@
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
                   >
                     <a
-                      href="https://algosone.ai/technology/"
+                      href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                       class="magnetic-item-off menu-link main-menu-link"
                       >Technology</a
                     >
@@ -367,7 +367,7 @@
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-31 current_page_item"
                   >
                     <a
-                      href="https://algosone.ai/profitability/"
+                      href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                       class="magnetic-item-off menu-link main-menu-link"
                       >Profitability</a
                     >
@@ -385,7 +385,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/markets/"
+                          href="/algosone-ai/pages/markets/algosone.ai/markets/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Markets</a
                         ><span class="description"
@@ -397,7 +397,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/about/"
+                          href="/algosone-ai/pages/about/algosone.ai/about/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >About</a
                         ><span class="description"
@@ -409,7 +409,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/affiliates/"
+                          href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Affiliates</a
                         ><span class="description"
@@ -421,7 +421,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/faq/"
+                          href="/algosone-ai/pages/faq/algosone.ai/faq/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >FAQ</a
                         ><span class="description"
@@ -433,7 +433,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/contact/"
+                          href="/algosone-ai/pages/contact/algosone.ai/contact/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Contact Us</a
                         ><span class="description"
@@ -446,7 +446,7 @@
                       >
                         <a
                           title="Aqronix clients reviews"
-                          href="https://algosone.ai/reviews/"
+                          href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Aqronix Reviews</a
                         ><span class="description"
@@ -459,7 +459,7 @@
                       >
                         <a
                           title="Aqronix is a licensed financial services provider"
-                          href="https://algosone.ai/trust-center/"
+                          href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Trust center</a
                         ><span class="description"
@@ -503,7 +503,7 @@
                       class="menu-item menu-item-type-custom menu-item-object-custom menu_item_wpglobus_menu_switch wpglobus-selector-link wpglobus-current-language menu-item-9999999999"
                     >
                       <a
-                        href="https://algosone.ai/profitability/"
+                        href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                         itemprop="url"
                         ><span
                           class="wpglobus_flag wpglobus_language_name wpglobus_flag_en"
@@ -591,7 +591,7 @@
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"
                           >
                             <a
-                              href="https://algosone.ai/technology/"
+                              href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                               itemprop="url"
                               >Technology</a
                             >
@@ -601,7 +601,7 @@
                             class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-31 current_page_item menu-item-486"
                           >
                             <a
-                              href="https://algosone.ai/profitability/"
+                              href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                               aria-current="page"
                               itemprop="url"
                               >Profitability</a
@@ -618,7 +618,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-488"
                               >
                                 <a
-                                  href="https://algosone.ai/markets/"
+                                  href="/algosone-ai/pages/markets/algosone.ai/markets/index.html"
                                   itemprop="url"
                                   >Markets</a
                                 >
@@ -628,7 +628,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-38"
                               >
                                 <a
-                                  href="https://algosone.ai/about/"
+                                  href="/algosone-ai/pages/about/algosone.ai/about/index.html"
                                   itemprop="url"
                                   >About</a
                                 >
@@ -638,7 +638,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-626"
                               >
                                 <a
-                                  href="https://algosone.ai/affiliates/"
+                                  href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                                   itemprop="url"
                                   >Affiliates</a
                                 >
@@ -648,7 +648,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289"
                               >
                                 <a
-                                  href="https://algosone.ai/faq/"
+                                  href="/algosone-ai/pages/faq/algosone.ai/faq/index.html"
                                   itemprop="url"
                                   >FAQ</a
                                 >
@@ -658,7 +658,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1480"
                               >
                                 <a
-                                  href="https://algosone.ai/contact/"
+                                  href="/algosone-ai/pages/contact/algosone.ai/contact/index.html"
                                   itemprop="url"
                                   >Contact Us</a
                                 >
@@ -668,7 +668,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3027"
                               >
                                 <a
-                                  href="https://algosone.ai/reviews/"
+                                  href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html"
                                   title="Aqronix clients reviews"
                                   itemprop="url"
                                   >Aqronix Reviews</a
@@ -679,7 +679,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9915"
                               >
                                 <a
-                                  href="https://algosone.ai/trust-center/"
+                                  href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                                   title="Aqronix is a licensed financial services provider"
                                   itemprop="url"
                                   >Trust center</a
@@ -1171,7 +1171,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"
                         >
                           <a
-                            href="https://algosone.ai/technology/"
+                            href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                             itemprop="url"
                             >Technology</a
                           >
@@ -1180,7 +1180,7 @@
                           id="menu-item-499"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-499"
                         >
-                          <a href="https://algosone.ai/markets/" itemprop="url"
+                          <a href="/algosone-ai/pages/markets/algosone.ai/markets/index.html" itemprop="url"
                             >Markets</a
                           >
                         </li>
@@ -1189,7 +1189,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-31 current_page_item menu-item-498"
                         >
                           <a
-                            href="https://algosone.ai/profitability/"
+                            href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                             aria-current="page"
                             itemprop="url"
                             >Profitability</a
@@ -1200,7 +1200,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-666"
                         >
                           <a
-                            href="https://algosone.ai/affiliates/"
+                            href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                             itemprop="url"
                             >Affiliates</a
                           >
@@ -1210,7 +1210,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9916"
                         >
                           <a
-                            href="https://algosone.ai/trust-center/"
+                            href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                             itemprop="url"
                             >Trust center</a
                           >
@@ -1224,7 +1224,7 @@
                           id="menu-item-503"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-503"
                         >
-                          <a href="https://algosone.ai/about/" itemprop="url"
+                          <a href="/algosone-ai/pages/about/algosone.ai/about/index.html" itemprop="url"
                             >About</a
                           >
                         </li>
@@ -1232,7 +1232,7 @@
                           id="menu-item-502"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-502"
                         >
-                          <a href="https://algosone.ai/faq/" itemprop="url"
+                          <a href="/algosone-ai/pages/faq/algosone.ai/faq/index.html" itemprop="url"
                             >FAQ</a
                           >
                         </li>
@@ -1240,7 +1240,7 @@
                           id="menu-item-3017"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3017"
                         >
-                          <a href="https://algosone.ai/reviews/" itemprop="url"
+                          <a href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" itemprop="url"
                             >Aqronix Reviews</a
                           >
                         </li>


### PR DESCRIPTION
## Summary
- update canonical, meta, and menu links on the profitability page to point to local copies

## Testing
- `grep -n "/algosone-ai/pages/" algosone-ai/pages/profitability/algosone.ai/profitability/index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_685bec9bf0e48320b6b3e685978b7d95