### PR TITLE
Update trust center links to local snapshots

### DIFF
--- a/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html
+++ b/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html
@@ -74,7 +74,7 @@ gtag("config", "GT-WR9QBQT");
   <meta content="image-prioritizer 1.0.0-beta2" name="generator"/>
   <script defer="" src="data:text/javascript;base64,KGZ1bmN0aW9uKHcsZCxzLGwsaSl7d1tsXT13W2xdfHxbXTt3W2xdLnB1c2goeydndG0uc3RhcnQnOm5ldyBEYXRlKCkuZ2V0VGltZSgpLGV2ZW50OidndG0uanMnfSk7dmFyIGY9ZC5nZXRFbGVtZW50c0J5VGFnTmFtZShzKVswXSxqPWQuY3JlYXRlRWxlbWVudChzKSxkbD1sIT0nZGF0YUxheWVyJz8nJmw9JytsOicnO2ouYXN5bmM9dHJ1ZTtqLnNyYz0naHR0cHM6Ly93d3cuZ29vZ2xldGFnbWFuYWdlci5jb20vZ3RtLmpzP2lkPScraStkbDtmLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKGosZik7fSkod2luZG93LGRvY3VtZW50LCdzY3JpcHQnLCdkYXRhTGF5ZXInLCdHVE0tTVZIU0hMRjgnKTs=">
   </script>
-  <link href="https://algosone.ai/trust-center/" hreflang="x-default" rel="alternate"/>
+  <link href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html" hreflang="x-default" rel="alternate"/>
   <link href="https://algosone.ai/es/trust-center/" hreflang="es-ES" rel="alternate"/>
   <link href="https://algosone.ai/de/trust-center/" hreflang="de-DE" rel="alternate"/>
   <link href="https://algosone.ai/it/trust-center/" hreflang="it-IT" rel="alternate"/>
@@ -134,13 +134,13 @@ gtag("config", "GT-WR9QBQT");
         <div class="menu" id="menu-header-1">
          
          <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-37">
-          <a class="magnetic-item-off menu-link main-menu-link" href="https://algosone.ai/technology/">
+          <a class="magnetic-item-off menu-link main-menu-link" href="/algosone-ai/pages/technology/algosone.ai/technology/index.html">
            Technology
           </a>
          </li>
          
          <li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-486">
-          <a class="magnetic-item-off menu-link main-menu-link" href="https://algosone.ai/profitability/">
+          <a class="magnetic-item-off menu-link main-menu-link" href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html">
            Profitability
           </a>
          </li>
@@ -150,7 +150,7 @@ gtag("config", "GT-WR9QBQT");
           </a>
           <ul class="sub-menu menu-odd menu-depth-1">
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-488">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/markets/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/markets/algosone.ai/markets/index.html">
              Markets
             </a>
             <span class="description">
@@ -158,7 +158,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-38">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/about/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/about/algosone.ai/about/index.html">
              About
             </a>
             <span class="description">
@@ -168,7 +168,7 @@ gtag("config", "GT-WR9QBQT");
            
            
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-626">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/affiliates/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html">
              Affiliates
             </a>
             <span class="description">
@@ -178,7 +178,7 @@ gtag("config", "GT-WR9QBQT");
            
            
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-289">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/faq/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/faq/algosone.ai/faq/index.html">
              FAQ
             </a>
             <span class="description">
@@ -188,7 +188,7 @@ gtag("config", "GT-WR9QBQT");
            
            
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1480">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/contact/">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/contact/algosone.ai/contact/index.html">
              Contact Us
             </a>
             <span class="description">
@@ -196,7 +196,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-3027">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/reviews/" title="Aqronix clients reviews">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" title="Aqronix clients reviews">
              Aqronix Reviews
             </a>
             <span class="description">
@@ -204,7 +204,7 @@ gtag("config", "GT-WR9QBQT");
             </span>
            </li>
            <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-3304 current_page_item" id="nav-menu-item-9915">
-            <a class="magnetic-item-off menu-link sub-menu-link" href="https://algosone.ai/trust-center/" title="Aqronix is a licensed financial services provider">
+            <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html" title="Aqronix is a licensed financial services provider">
              Trust center
             </a>
             <span class="description">
@@ -238,7 +238,7 @@ gtag("config", "GT-WR9QBQT");
            </a>
           </li>
           <li class="menu-item menu-item-type-custom menu-item-object-custom menu_item_wpglobus_menu_switch wpglobus-selector-link wpglobus-current-language menu-item-9999999999" id="menu-item-9999999999">
-           <a href="https://algosone.ai/trust-center/" itemprop="url">
+           <a href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html" itemprop="url">
             <span class="wpglobus_flag wpglobus_language_name wpglobus_flag_en">
              en
             </span>
@@ -306,13 +306,13 @@ gtag("config", "GT-WR9QBQT");
             <ul class="tt-ol-menu-list" id="menu-header-2">
              
              <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37" id="menu-item-37">
-              <a href="https://algosone.ai/technology/" itemprop="url">
+              <a href="/algosone-ai/pages/technology/algosone.ai/technology/index.html" itemprop="url">
                Technology
               </a>
              </li>
              
              <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-486" id="menu-item-486">
-              <a href="https://algosone.ai/profitability/" itemprop="url">
+              <a href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html" itemprop="url">
                Profitability
               </a>
              </li>
@@ -322,43 +322,43 @@ gtag("config", "GT-WR9QBQT");
               </a>
               <ul class="sub-menu">
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-488" id="menu-item-488">
-                <a href="https://algosone.ai/markets/" itemprop="url">
+                <a href="/algosone-ai/pages/markets/algosone.ai/markets/index.html" itemprop="url">
                  Markets
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-38" id="menu-item-38">
-                <a href="https://algosone.ai/about/" itemprop="url">
+                <a href="/algosone-ai/pages/about/algosone.ai/about/index.html" itemprop="url">
                  About
                 </a>
                </li>
                
                
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-626" id="menu-item-626">
-                <a href="https://algosone.ai/affiliates/" itemprop="url">
+                <a href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html" itemprop="url">
                  Affiliates
                 </a>
                </li>
                
                
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289" id="menu-item-289">
-                <a href="https://algosone.ai/faq/" itemprop="url">
+                <a href="/algosone-ai/pages/faq/algosone.ai/faq/index.html" itemprop="url">
                  FAQ
                 </a>
                </li>
                
                
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1480" id="menu-item-1480">
-                <a href="https://algosone.ai/contact/" itemprop="url">
+                <a href="/algosone-ai/pages/contact/algosone.ai/contact/index.html" itemprop="url">
                  Contact Us
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3027" id="menu-item-3027">
-                <a href="https://algosone.ai/reviews/" itemprop="url" title="Aqronix clients reviews">
+                <a href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" itemprop="url" title="Aqronix clients reviews">
                  Aqronix Reviews
                 </a>
                </li>
                <li class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-3304 current_page_item menu-item-9915" id="menu-item-9915">
-                <a aria-current="page" href="https://algosone.ai/trust-center/" itemprop="url" title="Aqronix is a licensed financial services provider">
+                <a aria-current="page" href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html" itemprop="url" title="Aqronix is a licensed financial services provider">
                  Trust center
                 </a>
                </li>
@@ -1186,35 +1186,35 @@ window.__mirage2 = {petok:"TSga1PJJYHesgylXOMqGvF2c3g5nZ_AMn4zCnfrgFT4-1800-0.0.
            <ul class="menu" id="menu-menu-footer-1">
             
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590" id="menu-item-1590">
-             <a href="https://algosone.ai/ai-crypto-trading/" itemprop="url">
+             <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">
               AI Crypto Trading
              </a>
             </li>
             
             
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18" id="menu-item-18">
-             <a href="https://algosone.ai/technology/" itemprop="url">
+             <a href="/algosone-ai/pages/technology/algosone.ai/technology/index.html" itemprop="url">
               Technology
              </a>
             </li>
             
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-499" id="menu-item-499">
-             <a href="https://algosone.ai/markets/" itemprop="url">
+             <a href="/algosone-ai/pages/markets/algosone.ai/markets/index.html" itemprop="url">
               Markets
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-498" id="menu-item-498">
-             <a href="https://algosone.ai/profitability/" itemprop="url">
+             <a href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html" itemprop="url">
               Profitability
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-666" id="menu-item-666">
-             <a href="https://algosone.ai/affiliates/" itemprop="url">
+             <a href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html" itemprop="url">
               Affiliates
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-3304 current_page_item menu-item-9916" id="menu-item-9916">
-             <a aria-current="page" href="https://algosone.ai/trust-center/" itemprop="url">
+             <a aria-current="page" href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html" itemprop="url">
               Trust center
              </a>
             </li>
@@ -1226,7 +1226,7 @@ window.__mirage2 = {petok:"TSga1PJJYHesgylXOMqGvF2c3g5nZ_AMn4zCnfrgFT4-1800-0.0.
            </div>
            <ul class="menu" id="menu-menu-footer-2">
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-503" id="menu-item-503">
-             <a href="https://algosone.ai/about/" itemprop="url">
+             <a href="/algosone-ai/pages/about/algosone.ai/about/index.html" itemprop="url">
               About
              </a>
             </li>
@@ -1237,12 +1237,12 @@ window.__mirage2 = {petok:"TSga1PJJYHesgylXOMqGvF2c3g5nZ_AMn4zCnfrgFT4-1800-0.0.
             
             
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-502" id="menu-item-502">
-             <a href="https://algosone.ai/faq/" itemprop="url">
+             <a href="/algosone-ai/pages/faq/algosone.ai/faq/index.html" itemprop="url">
               FAQ
              </a>
             </li>
             <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3017" id="menu-item-3017">
-             <a href="https://algosone.ai/reviews/" itemprop="url">
+             <a href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" itemprop="url">
               Aqronix Reviews
              </a>
             </li>


### PR DESCRIPTION
## Summary
- use local snapshot paths for menu links on the Trust Center page

## Testing
- `git diff --color --compact-summary`

------
https://chatgpt.com/codex/tasks/task_e_685becaf6070832081bd0fd3ba9ad48f