### PR TITLE
Update about page links to local paths

### DIFF
--- a/algosone-ai/pages/about/algosone.ai/about/index.html
+++ b/algosone-ai/pages/about/algosone.ai/about/index.html
@@ -351,7 +351,7 @@
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
                   >
                     <a
-                      href="https://algosone.ai/technology/"
+                      href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                       class="magnetic-item-off menu-link main-menu-link"
                       >Technology</a
                     >
@@ -361,7 +361,7 @@
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
                   >
                     <a
-                      href="https://algosone.ai/profitability/"
+                      href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                       class="magnetic-item-off menu-link main-menu-link"
                       >Profitability</a
                     >
@@ -379,7 +379,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/markets/"
+                          href="/algosone-ai/pages/markets/algosone.ai/markets/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Markets</a
                         ><span class="description"
@@ -391,7 +391,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-5 current_page_item"
                       >
                         <a
-                          href="https://algosone.ai/about/"
+                          href="/algosone-ai/pages/about/algosone.ai/about/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >About</a
                         ><span class="description"
@@ -403,7 +403,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/affiliates/"
+                          href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Affiliates</a
                         ><span class="description"
@@ -415,7 +415,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/faq/"
+                          href="/algosone-ai/pages/faq/algosone.ai/faq/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >FAQ</a
                         ><span class="description"
@@ -427,7 +427,7 @@
                         class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
                       >
                         <a
-                          href="https://algosone.ai/contact/"
+                          href="/algosone-ai/pages/contact/algosone.ai/contact/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Contact Us</a
                         ><span class="description"
@@ -440,7 +440,7 @@
                       >
                           <a
                             title="Aqronix clients reviews"
-                          href="https://algosone.ai/reviews/"
+                          href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html"
                             class="magnetic-item-off menu-link sub-menu-link"
                             >Aqronix Reviews</a
                           ><span class="description"
@@ -453,7 +453,7 @@
                       >
                         <a
                             title="Aqronix is a licensed financial services provider"
-                          href="https://algosone.ai/trust-center/"
+                          href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                           class="magnetic-item-off menu-link sub-menu-link"
                           >Trust center</a
                           ><span class="description"
@@ -496,7 +496,7 @@
                       id="menu-item-9999999999"
                       class="menu-item menu-item-type-custom menu-item-object-custom menu_item_wpglobus_menu_switch wpglobus-selector-link wpglobus-current-language menu-item-9999999999"
                     >
-                      <a href="https://algosone.ai/about/" itemprop="url"
+                      <a href="/algosone-ai/pages/about/algosone.ai/about/index.html" itemprop="url"
                         ><span
                           class="wpglobus_flag wpglobus_language_name wpglobus_flag_en"
                           >en</span
@@ -577,7 +577,7 @@
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"
                           >
                             <a
-                              href="https://algosone.ai/technology/"
+                              href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                               itemprop="url"
                               >Technology</a
                             >
@@ -587,7 +587,7 @@
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-486"
                           >
                             <a
-                              href="https://algosone.ai/profitability/"
+                              href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                               itemprop="url"
                               >Profitability</a
                             >
@@ -603,7 +603,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-488"
                               >
                                 <a
-                                  href="https://algosone.ai/markets/"
+                                  href="/algosone-ai/pages/markets/algosone.ai/markets/index.html"
                                   itemprop="url"
                                   >Markets</a
                                 >
@@ -613,7 +613,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-5 current_page_item menu-item-38"
                               >
                                 <a
-                                  href="https://algosone.ai/about/"
+                                  href="/algosone-ai/pages/about/algosone.ai/about/index.html"
                                   aria-current="page"
                                   itemprop="url"
                                   >About</a
@@ -624,7 +624,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-626"
                               >
                                 <a
-                                  href="https://algosone.ai/affiliates/"
+                                  href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                                   itemprop="url"
                                   >Affiliates</a
                                 >
@@ -634,7 +634,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-289"
                               >
                                 <a
-                                  href="https://algosone.ai/faq/"
+                                  href="/algosone-ai/pages/faq/algosone.ai/faq/index.html"
                                   itemprop="url"
                                   >FAQ</a
                                 >
@@ -644,7 +644,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1480"
                               >
                                 <a
-                                  href="https://algosone.ai/contact/"
+                                  href="/algosone-ai/pages/contact/algosone.ai/contact/index.html"
                                   itemprop="url"
                                   >Contact Us</a
                                 >
@@ -654,7 +654,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3027"
                               >
                                 <a
-                                  href="https://algosone.ai/reviews/"
+                                  href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html"
                                     title="Aqronix clients reviews"
                                   itemprop="url"
                                     >Aqronix Reviews</a
@@ -665,7 +665,7 @@
                                 class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9915"
                               >
                                 <a
-                                  href="https://algosone.ai/trust-center/"
+                                  href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                                     title="Aqronix is a licensed financial services provider"
                                   itemprop="url"
                                   >Trust center</a
@@ -1207,7 +1207,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590"
                         >
                           <a
-                            href="https://algosone.ai/ai-crypto-trading/"
+                            href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
                             itemprop="url"
                             >AI Crypto Trading</a
                           >
@@ -1217,7 +1217,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"
                         >
                           <a
-                            href="https://algosone.ai/technology/"
+                            href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
                             itemprop="url"
                             >Technology</a
                           >
@@ -1226,7 +1226,7 @@
                           id="menu-item-499"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-499"
                         >
-                          <a href="https://algosone.ai/markets/" itemprop="url"
+                          <a href="/algosone-ai/pages/markets/algosone.ai/markets/index.html" itemprop="url"
                             >Markets</a
                           >
                         </li>
@@ -1235,7 +1235,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-498"
                         >
                           <a
-                            href="https://algosone.ai/profitability/"
+                            href="/algosone-ai/pages/profitability/algosone.ai/profitability/index.html"
                             itemprop="url"
                             >Profitability</a
                           >
@@ -1245,7 +1245,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-666"
                         >
                           <a
-                            href="https://algosone.ai/affiliates/"
+                            href="/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html"
                             itemprop="url"
                             >Affiliates</a
                           >
@@ -1255,7 +1255,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9916"
                         >
                           <a
-                            href="https://algosone.ai/trust-center/"
+                            href="/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html"
                             itemprop="url"
                             >Trust center</a
                           >
@@ -1270,7 +1270,7 @@
                           class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-5 current_page_item menu-item-503"
                         >
                           <a
-                            href="https://algosone.ai/about/"
+                            href="/algosone-ai/pages/about/algosone.ai/about/index.html"
                             aria-current="page"
                             itemprop="url"
                             >About</a
@@ -1280,7 +1280,7 @@
                           id="menu-item-502"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-502"
                         >
-                          <a href="https://algosone.ai/faq/" itemprop="url"
+                          <a href="/algosone-ai/pages/faq/algosone.ai/faq/index.html" itemprop="url"
                             >FAQ</a
                           >
                         </li>
@@ -1288,7 +1288,7 @@
                           id="menu-item-3017"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3017"
                         >
-                            <a href="https://algosone.ai/reviews/" itemprop="url"
+                            <a href="/algosone-ai/pages/reviews/algosone.ai/reviews/index.html" itemprop="url"
                               >Aqronix Reviews</a
                           >
                         </li>


### PR DESCRIPTION
## Summary
- replace external `algosone.ai` links on about page with local archive paths

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685becb966ec8320998d0e215c59dce1