### PR TITLE
Remove open account button from AI crypto trading page

### DIFF
--- a/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
+++ b/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
@@ -365,19 +365,6 @@ gtag("config", "GT-WR9QBQT");
               <p>
                Aqronix offers trust and safety for crypto traders, as the platform is licensed to provide AI-based financial services, including digital assets, to a growing global userbase.
               </p>
-              <div class="action-block">
-               <a class="tt-btn tt-btn-light-outline cursor-alter ph-appear-off" href="https://app.aqronix.ai/registration" target="_blank">
-                <div data-hover="OPEN AN ACCOUNT">
-                 OPEN AN ACCOUNT
-                </div>
-                <span class="tt-btn-icon">
-                 <svg fill="none" height="20" viewBox="0 0 21 20" width="21" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M10.6667 0.5L20 10M20 10L10.6667 19.5M20 10L-4.15258e-07 10" stroke="white">
-                  </path>
-                 </svg>
-                </span>
-               </a>
-              </div>
              </div>
             </div>
            </div>


### PR DESCRIPTION
## Summary
- remove the "Open an Account" call-to-action button from the AI Crypto Trading page

## Testing
- `pytest -q`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bfdd5c2c0832088a1649742e201e6