### PR TITLE
Remove video section from AI crypto trading page

### DIFF
--- a/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
+++ b/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
@@ -491,14 +491,6 @@ gtag("config", "GT-WR9QBQT");
            </div>
           </div>
          </section>
-         <div class="insert-video">
-          <div class="container">
-           <div class="embed-container">
-            <iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" height="315" referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube.com/embed/QfbSefTvzI4?si=wY3rekryZ7d673B2" title="YouTube video player" width="560">
-            </iframe>
-           </div>
-          </div>
-         </div>
          <section class="s-ai--crypto-bot">
           <div class="container">
            <div class="s-header ph-appear-off">


### PR DESCRIPTION
## Summary
- remove the YouTube video block after the "Why Use an AI Crypto Trading Bot" section

## Testing
- `grep -n "insert-video" algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685bfeb7e5e0832087e8dfd088f4b5c2