### PR TITLE
Update button text on technology page

### DIFF
--- a/algosone-ai/pages/technology/algosone.ai/technology/index.html
+++ b/algosone-ai/pages/technology/algosone.ai/technology/index.html
@@ -342,8 +342,8 @@
                           </div>
 <div class="s-content">
 <a class="tt-btn tt-btn-light-outline cursor-alter ph-appear" href="https://app.algosone.ai/registration" target="_blank">
-<div data-hover="Open an Account">
-                                Open an Account
+<div data-hover="Try now">
+                                Try now
                               </div>
 <span class="tt-btn-icon"><svg fill="none" height="20" viewbox="0 0 21 20" width="21" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.6667 0.5L20 10M20 10L10.6667 19.5M20 10L-4.15258e-07 10" stroke="white"></path></svg></span>
@@ -383,8 +383,8 @@
                       </div>
 <div class="b-content">
 <a class="tt-btn tt-btn-light-outline cursor-alter ph-appear" href="https://app.algosone.ai/registration" target="_blank">
-<div data-hover="Open an Account">
-                            Open an Account
+<div data-hover="Try now">
+                            Try now
                           </div>
 <span class="tt-btn-icon"><svg fill="none" height="20" viewbox="0 0 21 20" width="21" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.6667 0.5L20 10M20 10L10.6667 19.5M20 10L-4.15258e-07 10" stroke="white"></path></svg></span>


### PR DESCRIPTION
## Summary
- change CTA button text from "Open an Account" to "Try now" on technology page

## Testing
- `grep -n "Try now" algosone-ai/pages/technology/algosone.ai/technology/index.html`


------
https://chatgpt.com/codex/tasks/task_e_685c087d81e08320b27990ef6d505b87