### PR TITLE
Fix button text on markets page

### DIFF
--- a/algosone-ai/pages/markets/algosone.ai/markets/index.html
+++ b/algosone-ai/pages/markets/algosone.ai/markets/index.html
@@ -372,8 +372,8 @@ gtag("config", "GT-WR9QBQT");
             </div>
             <div class="b-content">
              <a class="tt-btn tt-btn-light-outline cursor-alter ph-appear" href="https://app.algosone.ai/registration" target="_blank">
-              <div data-hover="Open an Account">
-               Open an Account
+              <div data-hover="try now">
+               try now
               </div>
               <span class="tt-btn-icon">
                <svg fill="none" height="20" viewbox="0 0 21 20" width="21" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- update the button label on the markets page from "Open an Account" to "try now"

## Testing
- `grep -n "try now" algosone-ai/pages/markets/algosone.ai/markets/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c0d2e8e888320b9b1a581f26849e0