### PR TITLE
Fix gaps on profitability page

### DIFF
--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -293,6 +293,11 @@
       type="text/javascript"
       src="../../widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js"
     ></script>
+    <style>
+      /* custom fixes for spacing issues */
+      #page-header { display: none; }
+      .figure-4 { display: none; }
+    </style>
   </head>
   <body
     class="wp-singular page-template-default page page-id-31 wp-embed-responsive wp-theme-common tt-transition tt-boxed tt-smooth-scroll tt-magic-cursor is-chrome"


### PR DESCRIPTION
## Summary
- remove huge header and decorative image via CSS to eliminate gaps on the profitability page

## Testing
- `npx htmlhint algosone-ai/pages/profitability/algosone.ai/profitability/index.html` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_685c55938c8083209077a785566b5104