### PR TITLE
Fix contact page spacing for mobile

### DIFF
--- a/algosone-ai/pages/contact/algosone.ai/contact/index.html
+++ b/algosone-ai/pages/contact/algosone.ai/contact/index.html
@@ -95,6 +95,11 @@ gtag("config", "GT-WR9QBQT");
     margin-top: 0;
     margin-bottom: 0;
    }
+   @media (max-width: 480px) {
+    .contacts-anim-off {
+     margin-top: -150px;
+    }
+   }
   </style>
  </head>
  <body class="wp-singular page-template-default page page-id-25 wp-embed-responsive wp-theme-common tt-transition tt-boxed tt-smooth-scroll tt-magic-cursor is-chrome">


### PR DESCRIPTION
## Summary
- reduce the gap before the Need Help section on the contact page

## Testing
- `grep -n contacts-anim-off algosone-ai/pages/contact/algosone.ai/contact/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c570f75fc83209fe57217b8ffa05c