### PR TITLE
Fix spacing on profitability page

### DIFF
--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -294,8 +294,11 @@
       src="../../widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js"
     ></script>
     <style>
-      /* custom fixes for spacing issues */
-      #page-header { display: none; }
+      /* custom spacing fixes */
+      #page-header .page-header-inner {
+        padding-top: 100px;
+        padding-bottom: 40px;
+      }
       .figure-4 { display: none; }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- keep Profitability header visible but reduce padding

## Testing
- `tidy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5788aac08320a701eca3a61c4565