### PR TITLE
Fix mobile gap on about page

### DIFF
--- a/algosone-ai/pages/about/algosone.ai/about/index.html
+++ b/algosone-ai/pages/about/algosone.ai/about/index.html
@@ -145,7 +145,10 @@
 <script defer="" src="data:text/javascript;base64,CiAgICAgICAgbGV0IENVUlJFTlRfU0lURSA9ICdodHRwczovL2FsZ29zb25lLmFpJzsKICAgICAgICBsZXQgX2hoID0gMDsKICAgIA=="></script>
 <script defer="" src="../../widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" type="text/javascript"></script>
 <style>
-@media (max-width:767px){.s-about--why{padding-top:60px;}}
+@media (max-width:767px){
+  .s-about--start{padding-top:20vh;min-height:80vh;}
+  .s-about--why{padding-top:40px;}
+}
 </style>
 </head>
 <body class="wp-singular page-template-default page page-id-5 wp-embed-responsive wp-theme-common tt-transition tt-boxed tt-smooth-scroll tt-magic-cursor is-chrome">


### PR DESCRIPTION
## Summary
- tweak mobile CSS for about page to reduce spacing after the AI-first section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c58dabedc8320a5d6ab4102bddab7