### PR TITLE
Fix mobile gap in About hero section

### DIFF
--- a/algosone-ai/pages/about/algosone.ai/about/index.html
+++ b/algosone-ai/pages/about/algosone.ai/about/index.html
@@ -146,7 +146,9 @@
 <script defer="" src="../../widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" type="text/javascript"></script>
 <style>
 @media (max-width:767px){
-  .s-about--start{padding-top:20vh;min-height:80vh;}
+  /* Reduced section height for mobile to shrink the gap below
+     the "AI-FIRST. HUMAN-GROUNDED." header */
+  .s-about--start{padding-top:10vh;min-height:70vh;}
   .s-about--why{padding-top:40px;}
 }
 </style>


### PR DESCRIPTION
## Summary
- tweak mobile CSS for the "AI-FIRST. HUMAN-GROUNDED." block so that the following section starts higher

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5a83bda083209ce40eef6fe61571