### PR TITLE
Fix mobile spacing before help section

### DIFF
--- a/algosone-ai/pages/contact/algosone.ai/contact/index.html
+++ b/algosone-ai/pages/contact/algosone.ai/contact/index.html
@@ -97,7 +97,8 @@ gtag("config", "GT-WR9QBQT");
    }
    @media (max-width: 480px) {
     .contacts-anim-off {
-     margin-top: -150px;
+     margin-top: -200px;
+     height: 250px;
     }
    }
   </style>


### PR DESCRIPTION
## Summary
- tweak contact page mobile styles to reduce spacing before "Need help" heading

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c5aba52288320b5491c07a421495f