### PR TITLE
Fix spacing on profitability page

### DIFF
--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -297,18 +297,18 @@
       /* custom spacing fixes */
       #page-header .page-header-inner {
         padding-top: 100px;
-        padding-bottom: 40px;
+        padding-bottom: 20px;
       }
       .figure-4 { display: none; }
       /* spacing tweaks for profitability page */
       @media (min-width:1024px) {
         /* smaller gap before "Grow your capital" section */
         .s-profit--about {
-          padding-top: 30px;
+          padding-top: 20px;
         }
         /* smaller gap after AI optimized trading contracts */
         .s-profit--plans {
-          margin-bottom: 40px;
+          margin-bottom: 20px;
         }
       }
       @media (max-width:1023px) {


### PR DESCRIPTION
## Summary
- adjust padding for the hero section
- tighten spacing before `Grow your capital` section
- tighten spacing after `AI Optimized` contracts section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5b134c008320b2b23f7577cf4cd7