### PR TITLE
Fix mobile spacing before help section

### DIFF
--- a/algosone-ai/pages/contact/algosone.ai/contact/index.html
+++ b/algosone-ai/pages/contact/algosone.ai/contact/index.html
@@ -101,7 +101,7 @@ gtag("config", "GT-WR9QBQT");
        height: 250px;
       }
       .s-contact--form {
-       margin-top: 80px;
+       margin-top: 40px;
       }
     }
    </style>


### PR DESCRIPTION
## Summary
- reduce vertical gap on contact page for mobile by lowering `.s-contact--form` margin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5cc0604883209a525b42a908e0e5