### PR TITLE
Fix mobile spacing after hero on about page

### DIFF
--- a/algosone-ai/pages/about/algosone.ai/about/index.html
+++ b/algosone-ai/pages/about/algosone.ai/about/index.html
@@ -150,6 +150,8 @@
      the "AI-FIRST. HUMAN-GROUNDED." header */
   /* Further reduce the hero height on small screens */
   .s-about--start{padding-top:10vh;min-height:50vh;}
+  /* Override default hero height */
+  #page-header.ph-full{min-height:60vh!important;}
   /* Tighten spacing before the next section */
   .s-about--why{padding-top:20px;}
 }


### PR DESCRIPTION
## Summary
- tweak mobile styles for the about page hero
- enforce smaller minimum height on mobile to reduce the gap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5c7fc5e8832089405ff0bae50b76