### PR TITLE
Fix contact page spacing

### DIFF
--- a/algosone-ai/pages/contact/algosone.ai/contact/index.html
+++ b/algosone-ai/pages/contact/algosone.ai/contact/index.html
@@ -103,6 +103,9 @@ gtag("config", "GT-WR9QBQT");
       .s-contact--form {
        margin-top: 40px;
       }
+      .contact-lottie-1 {
+       margin-bottom: -240px;
+      }
     }
    </style>
  </head>


### PR DESCRIPTION
## Summary
- tweak margin for the contact page animation on mobile so the "Need Help" section sits closer to the top

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5d99630c832081448797dda130f0