### PR TITLE
Fix mobile gap below hero on about page

### DIFF
--- a/algosone-ai/pages/about/algosone.ai/about/index.html
+++ b/algosone-ai/pages/about/algosone.ai/about/index.html
@@ -151,7 +151,7 @@
   /* Further reduce the hero height on small screens */
   .s-about--start{padding-top:10vh;min-height:50vh;}
   /* Override default hero height */
-  #page-header.ph-full{min-height:60vh!important;}
+  #page-header.ph-full{min-height:40vh!important;}
   /* Tighten spacing before the next section */
   .s-about--why{padding-top:20px;}
 }


### PR DESCRIPTION
## Summary
- override mobile min-height for the about page hero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5dfa7b988320836db4cb361df48c