### PR TITLE
Fix profitability hero spacing

### DIFF
--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -296,12 +296,12 @@
   <style>
       /* custom spacing fixes */
       #page-header .page-header-inner {
-        padding-top: 100px;
+        padding-top: 60px;
         padding-bottom: 20px;
       }
       /* reduce hero height to remove large gap above "Grow your capital" */
       #page-header.ph-full {
-        min-height: 60vh !important;
+        min-height: 40vh !important;
       }
       .figure-4 { display: none; }
       /* spacing tweaks for profitability page */


### PR DESCRIPTION
## Summary
- shrink the hero block to reduce empty space above "Grow your capital" section

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685c5ec47aec8320976a87c7699052de