### PR TITLE
Add AI Crypto Trading link on profitability page

### DIFF
--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -385,17 +385,32 @@
                 </div>
               </div>
               <div class="col-middle">
-                <div id="menu-header-1" class="menu">
-                  <li
-                    id="nav-menu-item-37"
-                    class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
-                  >
-                    <a
-                      href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
-                      class="magnetic-item-off menu-link main-menu-link"
-                      >Technology</a
+                  <div id="menu-header-1" class="menu">
+                    <li
+                      id="nav-menu-item-487"
+                      class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children"
                     >
-                  </li>
+                      <a class="magnetic-item-off menu-link main-menu-link" >AI Trading</a>
+                      <ul class="sub-menu menu-odd menu-depth-1">
+                        <li
+                          id="nav-menu-item-1584"
+                          class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page"
+                        >
+                          <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html">AI Crypto Trading</a>
+                          <span class="description">Profit from a wide range of crypto assets.</span>
+                        </li>
+                      </ul>
+                    </li>
+                    <li
+                      id="nav-menu-item-37"
+                      class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
+                    >
+                      <a
+                        href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
+                        class="magnetic-item-off menu-link main-menu-link"
+                        >Technology</a
+                      >
+                    </li>
                   <li
                     id="nav-menu-item-486"
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-31 current_page_item"
@@ -535,17 +550,25 @@
                   <div class="tt-ol-menu-holder">
                     <div class="tt-ol-menu-inner tt-wrap">
                       <div class="tt-ol-menu-content">
-                        <ul id="menu-header-2" class="tt-ol-menu-list">
-                          <li
-                            id="menu-item-37"
-                            class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"
-                          >
-                            <a
-                              href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
-                              itemprop="url"
-                              >Technology</a
+                          <ul id="menu-header-2" class="tt-ol-menu-list">
+                            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-487" id="menu-item-487">
+                              <a  itemprop="url">AI Trading</a>
+                              <ul class="sub-menu">
+                               <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1584" id="menu-item-1584">
+                                <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">AI Crypto Trading</a>
+                               </li>
+                              </ul>
+                             </li>
+                            <li
+                              id="menu-item-37"
+                              class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"
                             >
-                          </li>
+                              <a
+                                href="/algosone-ai/pages/technology/algosone.ai/technology/index.html"
+                                itemprop="url"
+                                >Technology</a
+                              >
+                            </li>
                           <li
                             id="menu-item-486"
                             class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-31 current_page_item menu-item-486"
@@ -1088,6 +1111,9 @@
                     <div>
                       <div class="f-head text-center">Get to Know Us</div>
                       <ul id="menu-menu-footer-1" class="menu">
+                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590" id="menu-item-1590">
+                          <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">AI Crypto Trading</a>
+                        </li>
                         <li
                           id="menu-item-18"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"


### PR DESCRIPTION
## Summary
- update profitability page navigation with AI Crypto Trading link
- include overlay and footer references

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c6026e5d083209240af63806c9b3b