### PR TITLE
Fix FAQ footer

### DIFF
--- a/algosone-ai/pages/faq/algosone.ai/faq/index.html
+++ b/algosone-ai/pages/faq/algosone.ai/faq/index.html
@@ -1303,6 +1303,9 @@
                     <div>
                       <div class="f-head text-center">Get to Know Us</div>
                       <ul id="menu-menu-footer-1" class="menu">
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590" id="menu-item-1590">
+<a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">AI Crypto Trading</a>
+</li>
                         <li
                           id="menu-item-18"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"


### PR DESCRIPTION
## Summary
- add AI Crypto Trading link to the FAQ page footer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c60a9098c8320801f2cae232b8c13