### PR TITLE
Add AI Crypto Trading link to reviews page

### DIFF
--- a/algosone-ai/pages/reviews/algosone.ai/reviews/index.html
+++ b/algosone-ai/pages/reviews/algosone.ai/reviews/index.html
@@ -348,7 +348,18 @@
               </div>
               <div class="col-middle">
                 <div id="menu-header-1" class="menu">
-                  
+
+                  <li
+                    id="nav-menu-item-1584"
+                    class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
+                  >
+                    <a
+                      href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
+                      class="magnetic-item-off menu-link main-menu-link"
+                      >AI Crypto Trading</a
+                    >
+                  </li>
+
                   <li
                     id="nav-menu-item-37"
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
@@ -506,7 +517,18 @@
                     <div class="tt-ol-menu-inner tt-wrap">
                       <div class="tt-ol-menu-content">
                         <ul id="menu-header-2" class="tt-ol-menu-list">
-                          
+
+                          <li
+                            id="menu-item-1584"
+                            class="menu-item menu-item-type-post_type menu-item-object-page"
+                          >
+                            <a
+                              href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
+                              itemprop="url"
+                              >AI Crypto Trading</a
+                            >
+                          </li>
+
                           <li
                             id="menu-item-37"
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"


### PR DESCRIPTION
## Summary
- add missing link to **AI Crypto Trading** on reviews page header
- include new item in overlay menu

## Testing
- `grep -n "AI Crypto Trading" algosone-ai/pages/reviews/algosone.ai/reviews/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c60d0204c832083cab5766b4d2a29