### PR TITLE
Add AI Crypto Trading link

### DIFF
--- a/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html
+++ b/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html
@@ -363,7 +363,21 @@
               </div>
               <div class="col-middle">
                 <div id="menu-header-1" class="menu">
-                  <li
+<li class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children" id="nav-menu-item-487">
+  <a class="magnetic-item-off menu-link main-menu-link" >
+   AI Trading
+  </a>
+  <ul class="sub-menu menu-odd menu-depth-1">
+   <li class="item sub-menu-item menu-item-odd menu-item-depth-1 menu-item menu-item-type-post_type menu-item-object-page" id="nav-menu-item-1584">
+    <a class="magnetic-item-off menu-link sub-menu-link" href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html">
+     AI Crypto Trading
+    </a>
+    <span class="description">
+     Profit from a wide range of crypto assets.
+    </span>
+   </li>
+  </ul>
+</li>
                     id="nav-menu-item-37"
                     class="item main-menu-item menu-item-even menu-item-depth-0 menu-item menu-item-type-post_type menu-item-object-page"
                   >
@@ -513,7 +527,18 @@
                     <div class="tt-ol-menu-inner tt-wrap">
                       <div class="tt-ol-menu-content">
                         <ul id="menu-header-2" class="tt-ol-menu-list">
-                          <li
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-487" id="menu-item-487">
+  <a  itemprop="url">
+   AI Trading
+  </a>
+  <ul class="sub-menu">
+   <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1584" id="menu-item-1584">
+    <a href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html" itemprop="url">
+     AI Crypto Trading
+    </a>
+   </li>
+  </ul>
+</li>
                             id="menu-item-37"
                             class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"
                           >


### PR DESCRIPTION
## Summary
- add AI Trading menu item linking to AI Crypto Trading page in header
- include same link in overlay navigation menu

## Testing
- `apt-get update`
- `apt-get install -y ed`


------
https://chatgpt.com/codex/tasks/task_e_685c60753b58832084b0ce19ec27cbad