### PR TITLE
Add missing AI Crypto Trading footer link

### DIFF
--- a/algosone-ai/pages/reviews/algosone.ai/reviews/index.html
+++ b/algosone-ai/pages/reviews/algosone.ai/reviews/index.html
@@ -1219,10 +1219,16 @@
                     <div>
                       <div class="f-head text-center">Get to Know Us</div>
                       <ul id="menu-menu-footer-1" class="menu">
-                        
-                        
-                        
-                        
+                        <li
+                          id="menu-item-1590"
+                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590"
+                        >
+                          <a
+                            href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
+                            itemprop="url"
+                            >AI Crypto Trading</a
+                          >
+                        </li>
                         <li
                           id="menu-item-18"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"


### PR DESCRIPTION
## Summary
- add AI Crypto Trading link to the reviews page footer

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c626fa04483209697d840935f2056