### PR TITLE
Add AI Crypto Trading link in FAQ footer

### DIFF
--- a/algosone-ai/pages/faq/algosone.ai/faq/index.html
+++ b/algosone-ai/pages/faq/algosone.ai/faq/index.html
@@ -1304,6 +1304,16 @@
                       <div class="f-head text-center">Get to Know Us</div>
                       <ul id="menu-menu-footer-1" class="menu">
                         <li
+                          id="menu-item-1590"
+                          class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1590"
+                        >
+                          <a
+                            href="/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html"
+                            itemprop="url"
+                            >AI Crypto Trading</a
+                          >
+                        </li>
+                        <li
                           id="menu-item-18"
                           class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18"
                         >


### PR DESCRIPTION
## Summary
- add AI Crypto Trading link to FAQ page footer menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c6277467c8320bedbf43221dba3b2