### PR TITLE
Remove mobile store icons from footer

### DIFF
--- a/algosone-ai/pages/about/algosone.ai/about/index.html
+++ b/algosone-ai/pages/about/algosone.ai/about/index.html
@@ -490,12 +490,6 @@ Aqronix is not for hype. It's for results.</div>
 <div class="app_block">
 <br/>
 <div class="links">
-<a class="apple_store" href="https://apps.apple.com/us/app/algosone/id6469542851" target="_blank">
-<img alt="Apple Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/apple_v%3D2.svg"/><br/>
-</a>
-<a class="google_store" href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone" target="_blank">
-<img alt="Google Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/google_v%3D1.svg"/>
-</a>
 <div class="app-tooltip">
 <div class="img-qr">
 <svg height="138" viewbox="0 0 29 29" width="138" xmlns="http://www.w3.org/2000/svg">

--- a/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html
+++ b/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html
@@ -962,31 +962,7 @@
                       <br />
                       <div class="links">
                         <a
-                          class="apple_store"
-                          target="_blank"
-                          href="https://apps.apple.com/us/app/algosone/id6469542851"
-                        >
-                          <img
-                            data-od-added-loading=""
-                            data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[7][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]"
-                            loading="lazy"
-                            src="../assets/themes/common/assets/images/apple_v%3D2.svg"
-                            alt="Apple Store"
-                          /><br />
-                        </a>
                         <a
-                          class="google_store"
-                          target="_blank"
-                          href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone"
-                        >
-                          <img
-                            data-od-added-loading=""
-                            data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[7][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]"
-                            loading="lazy"
-                            src="../assets/themes/common/assets/images/google_v%3D1.svg"
-                            alt="Google Store"
-                          />
-                        </a>
                         <div class="app-tooltip">
                           <div class="img-qr">
                             <svg

--- a/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
+++ b/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
@@ -642,13 +642,6 @@ gtag("config", "GT-WR9QBQT");
           <div class="app_block">
            <br/>
            <div class="links">
-            <a class="apple_store" href="https://apps.apple.com/us/app/aqronix/id6469542851" target="_blank">
-             <img alt="Apple Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[8][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/apple_v%3D2.svg"/>
-             <br/>
-            </a>
-            <a class="google_store" href="https://play.google.com/store/apps/details?id=ai.one.algos.aqronix" target="_blank">
-             <img alt="Google Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[8][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/google_v%3D1.svg"/>
-            </a>
             <div class="app-tooltip">
              <div class="img-qr">
               <svg height="138" viewBox="0 0 29 29" width="138" xmlns="http://www.w3.org/2000/svg">

--- a/algosone-ai/pages/contact/algosone.ai/contact/index.html
+++ b/algosone-ai/pages/contact/algosone.ai/contact/index.html
@@ -485,13 +485,6 @@ gtag("config", "GT-WR9QBQT");
           <div class="app_block">
            <br/>
            <div class="links">
-            <a class="apple_store" href="https://apps.apple.com/us/app/algosone/id6469542851" target="_blank">
-             <img alt="Apple Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/apple_v%3D2.svg"/>
-             <br/>
-            </a>
-            <a class="google_store" href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone" target="_blank">
-             <img alt="Google Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/google_v%3D1.svg"/>
-            </a>
             <div class="app-tooltip">
              <div class="img-qr">
               <svg height="138" viewbox="0 0 29 29" width="138" xmlns="http://www.w3.org/2000/svg">

--- a/algosone-ai/pages/contact/algosone.ai/contact/transparent/index.html
+++ b/algosone-ai/pages/contact/algosone.ai/contact/transparent/index.html
@@ -520,13 +520,6 @@ gtag("config", "GT-WR9QBQT");
           <div class="app_block">
            <br/>
            <div class="links">
-            <a class="apple_store" href="https://apps.apple.com/us/app/algosone/id6469542851" target="_blank">
-             <img alt="Apple Store" src="../../assets/themes/common/assets/images/apple_v%3D2.svg"/>
-             <br/>
-            </a>
-            <a class="google_store" href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone" target="_blank">
-             <img alt="Google Store" src="../../assets/themes/common/assets/images/google_v%3D1.svg"/>
-            </a>
             <div class="app-tooltip">
              <div class="img-qr">
               <svg height="138" viewbox="0 0 29 29" width="138" xmlns="http://www.w3.org/2000/svg">

--- a/algosone-ai/pages/faq/algosone.ai/faq/index.html
+++ b/algosone-ai/pages/faq/algosone.ai/faq/index.html
@@ -1219,31 +1219,7 @@
                       <br />
                       <div class="links">
                         <a
-                          class="apple_store"
-                          target="_blank"
-                          href="https://apps.apple.com/us/app/algosone/id6469542851"
-                        >
-                          <img
-                            data-od-added-loading=""
-                            data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]"
-                            loading="lazy"
-                            src="../assets/themes/common/assets/images/apple_v%3D2.svg"
-                            alt="Apple Store"
-                          /><br />
-                        </a>
                         <a
-                          class="google_store"
-                          target="_blank"
-                          href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone"
-                        >
-                          <img
-                            data-od-added-loading=""
-                            data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]"
-                            loading="lazy"
-                            src="../assets/themes/common/assets/images/google_v%3D1.svg"
-                            alt="Google Store"
-                          />
-                        </a>
                         <div class="app-tooltip">
                           <div class="img-qr">
                             <svg

--- a/algosone-ai/pages/markets/algosone.ai/markets/index.html
+++ b/algosone-ai/pages/markets/algosone.ai/markets/index.html
@@ -532,13 +532,6 @@ gtag("config", "GT-WR9QBQT");
           <div class="app_block">
            <br/>
            <div class="links">
-            <a class="apple_store" href="https://apps.apple.com/us/app/algosone/id6469542851" target="_blank">
-             <img alt="Apple Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/apple_v%3D2.svg"/>
-             <br/>
-            </a>
-            <a class="google_store" href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone" target="_blank">
-             <img alt="Google Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/google_v%3D1.svg"/>
-            </a>
             <div class="app-tooltip">
              <div class="img-qr">
               <svg height="138" viewbox="0 0 29 29" width="138" xmlns="http://www.w3.org/2000/svg">

--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -1004,31 +1004,7 @@
                       <br />
                       <div class="links">
                         <a
-                          class="apple_store"
-                          target="_blank"
-                          href="https://apps.apple.com/us/app/algosone/id6469542851"
-                        >
-                          <img
-                            data-od-added-loading=""
-                            data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]"
-                            loading="lazy"
-                            src="../assets/themes/common/assets/images/apple_v%3D2.svg"
-                            alt="Apple Store"
-                          /><br />
-                        </a>
                         <a
-                          class="google_store"
-                          target="_blank"
-                          href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone"
-                        >
-                          <img
-                            data-od-added-loading=""
-                            data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[6][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]"
-                            loading="lazy"
-                            src="../assets/themes/common/assets/images/google_v%3D1.svg"
-                            alt="Google Store"
-                          />
-                        </a>
                         <div class="app-tooltip">
                           <div class="img-qr">
                             <svg

--- a/algosone-ai/pages/reviews/algosone.ai/reviews/index.html
+++ b/algosone-ai/pages/reviews/algosone.ai/reviews/index.html
@@ -1018,31 +1018,7 @@
                       <br />
                       <div class="links">
                         <a
-                          class="apple_store"
-                          target="_blank"
-                          href="https://apps.apple.com/us/app/algosone/id6469542851"
-                        >
-                          <img
-                            data-od-added-loading=""
-                            data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[7][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]"
-                            loading="lazy"
-                            src="../assets/themes/common/assets/images/apple_v%3D2.svg"
-                            alt="Apple Store"
-                          /><br />
-                        </a>
                         <a
-                          class="google_store"
-                          target="_blank"
-                          href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone"
-                        >
-                          <img
-                            data-od-added-loading=""
-                            data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[7][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]"
-                            loading="lazy"
-                            src="../assets/themes/common/assets/images/google_v%3D1.svg"
-                            alt="Google Store"
-                          />
-                        </a>
                         <div class="app-tooltip">
                           <div class="img-qr">
                             <svg

--- a/algosone-ai/pages/technology/algosone.ai/technology/index.html
+++ b/algosone-ai/pages/technology/algosone.ai/technology/index.html
@@ -477,12 +477,6 @@
 <div class="app_block">
 <br/>
 <div class="links">
-<a class="apple_store" href="https://apps.apple.com/us/app/algosone/id6469542851" target="_blank">
-<img alt="Apple Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[5][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/apple_v%3D2.svg"/><br/>
-</a>
-<a class="google_store" href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone" target="_blank">
-<img alt="Google Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[5][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/google_v%3D1.svg"/>
-</a>
 <div class="app-tooltip">
 <div class="img-qr">
 <svg height="138" viewbox="0 0 29 29" width="138" xmlns="http://www.w3.org/2000/svg">

--- a/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html
+++ b/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html
@@ -902,13 +902,6 @@ window.__mirage2 = {petok:"TSga1PJJYHesgylXOMqGvF2c3g5nZ_AMn4zCnfrgFT4-1800-0.0.
           <div class="app_block">
            <br/>
            <div class="links">
-            <a class="apple_store" href="https://apps.apple.com/us/app/algosone/id6469542851" target="_blank">
-             <img alt="Apple Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[7][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[1][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/apple_v%3D2.svg"/>
-             <br/>
-            </a>
-            <a class="google_store" href="https://play.google.com/store/apps/details?id=ai.one.algos.algosone" target="_blank">
-             <img alt="Google Store" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[7][self::FOOTER]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[3][self::DIV]/*[2][self::DIV]/*[2][self::A]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/google_v%3D1.svg"/>
-            </a>
             <div class="app-tooltip">
              <div class="img-qr">
               <svg height="138" viewbox="0 0 29 29" width="138" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- delete Play Market and App Store icons from footer on every page snapshot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c6a79074083209b420b8daacf9a13