### PR TITLE
Fix hero image layout on homepage

### DIFF
--- a/algosone-ai/pages/home/algosone.ai/index.html
+++ b/algosone-ai/pages/home/algosone.ai/index.html
@@ -265,6 +265,24 @@
       href="https://algosone.ai/assets/themes/common/assets/video/Robot_1_v=2.mp4"
       media="screen and (width <= 782px)"
     />
+    <style>
+      .s-home--slider--new .slider-content {
+        align-items: center;
+        gap: 20px;
+      }
+      .s-home--slider--new .slider-content img.slide-img {
+        order: 2;
+        max-width: 45%;
+        margin-left: 20px;
+        z-index: 0;
+      }
+      .s-home--slider--new .slider-content .content {
+        order: 1;
+      }
+      .s-home--slider--new .title {
+        font-size: 3rem;
+      }
+    </style>
   </head>
   <body
     class="home wp-singular page-template page-template-front-page page-template-front-page-php page page-id-44 wp-embed-responsive wp-theme-common tt-transition tt-boxed tt-smooth-scroll tt-magic-cursor is-chrome"
@@ -1347,10 +1365,10 @@
                     <div class="slider-content slide1">
                       <div class="content">
                         <div>
-                          <div class="title">
+                          <h1 class="title home-slider-title">
                             SIT BACK, RELAX,<br />
                             EARN A PROFIT
-                          </div>
+                          </h1>
                           <div class="desc">
                             Grow your savings with a state-of-the-art Ai-based trading system
                           </div>


### PR DESCRIPTION
## Summary
- adjust homepage hero layout so the image aligns right
- enlarge the slider header text

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ea529057c8320b1a863f4e24a5794