### PR TITLE
Fix technology page image paths

### DIFF
--- a/algosone-ai/pages/technology/algosone.ai/technology/index.html
+++ b/algosone-ai/pages/technology/algosone.ai/technology/index.html
@@ -147,7 +147,7 @@
 <link href="https://algosone.ai/fr/technology/" hreflang="fr-FR" rel="alternate"/>
 <script defer="" src="data:text/javascript;base64,CiAgICAgICAgbGV0IENVUlJFTlRfU0lURSA9ICdodHRwczovL2FsZ29zb25lLmFpJzsKICAgICAgICBsZXQgX2hoID0gMDsKICAgIA=="></script>
 <script defer="" src="../../widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" type="text/javascript"></script>
-<link as="image" data-od-added-tag="" fetchpriority="high" href="../../../../../new_photos/1.png" media="screen and (600px &lt; width &lt;= 782px)" rel="preload"/>
+<link as="image" data-od-added-tag="" fetchpriority="high" href="../../new_photos/1.png" media="screen and (600px &lt; width &lt;= 782px)" rel="preload"/>
 <link as="image" data-od-added-tag="" fetchpriority="high" href="https://algosone.ai/assets/themes/common/assets/images/technology/bg.jpg" media="screen and (782px &lt; width)" rel="preload"/>
 </head>
 <body class="wp-singular page-template-default page page-id-16 wp-embed-responsive wp-theme-common tt-transition tt-boxed tt-smooth-scroll tt-magic-cursor is-chrome">
@@ -340,7 +340,7 @@
 </div>
 </div>
 <div class="col-right">
-<img alt="Dashboard" class="ph-appear" data-cfsrc="../../../../../new_photos/1.png" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[2][self::DIV]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::IMG]" style="display: none; visibility: hidden"/><noscript><img alt="Dashboard" class="ph-appear" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[2][self::DIV]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::IMG]" src="../../../../../new_photos/1.png"/></noscript>
+<img alt="Dashboard" class="ph-appear" data-cfsrc="../../new_photos/1.png" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[2][self::DIV]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::IMG]" style="display: none; visibility: hidden"/><noscript><img alt="Dashboard" class="ph-appear" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[2][self::DIV]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::IMG]" src="../../new_photos/1.png"/></noscript>
 <div class="gradient"></div>
 </div>
 </div>
@@ -373,7 +373,7 @@
 </div>
 <div class="col-right">
 <div class="figure">
-<img alt="Image" class="laptop anim-fadeinup" data-cfsrc="../../../../../new_photos/2.png" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[3][self::DIV]/*[1][self::DIV]/*[1][self::SECTION]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::IMG]" loading="lazy" style="display: none; visibility: hidden"/><noscript><img alt="Image" class="laptop anim-fadeinup" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[3][self::DIV]/*[1][self::DIV]/*[1][self::SECTION]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::IMG]" loading="lazy" src="../../../../../new_photos/2.png"/></noscript>
+<img alt="Image" class="laptop anim-fadeinup" data-cfsrc="../../new_photos/2.png" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[3][self::DIV]/*[1][self::DIV]/*[1][self::SECTION]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::IMG]" loading="lazy" style="display: none; visibility: hidden"/><noscript><img alt="Image" class="laptop anim-fadeinup" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[3][self::DIV]/*[1][self::DIV]/*[1][self::SECTION]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::IMG]" loading="lazy" src="../../new_photos/2.png"/></noscript>
 </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- update image paths on Technology page to use the page local `new_photos` folder instead of the project root

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ef2688ce08320bdc72514bae4f040