### PR TITLE
Remove logo from trust center section

### DIFF
--- a/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html
+++ b/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html
@@ -794,12 +794,6 @@ window.__mirage2 = {petok:"TSga1PJJYHesgylXOMqGvF2c3g5nZ_AMn4zCnfrgFT4-1800-0.0.
             There is a cap on the total supply of AIAO that can ever be minted, of 1B tokens
            </p>
           </div>
-          <div class="coin">
-           <img data-cfsrc="../assets/themes/common/assets/images/logo.svg" data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[2][self::DIV]/*[9][self::SECTION]/*[1][self::DIV]/*[4][self::DIV]/*[2][self::DIV]/*[1][self::IMG]" loading="lazy" style="display:none;visibility:hidden;"/>
-           <noscript>
-            <img data-od-added-loading="" data-od-xpath="/HTML/BODY/DIV[@id='_page']/*[1][self::MAIN]/*[3][self::DIV]/*[4][self::DIV]/*[2][self::DIV]/*[9][self::SECTION]/*[1][self::DIV]/*[4][self::DIV]/*[2][self::DIV]/*[1][self::IMG]" loading="lazy" src="../assets/themes/common/assets/images/logo.svg"/>
-           </noscript>
-          </div>
           <div class="feature">
            <p>
             At the start of each of the 16 presale stages, the token price will be 50% higher


### PR DESCRIPTION
## Summary
- remove decorative logo from the "Price appreciation" section in the trust center page

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_685f8e78485483209f3a9b7d935dd220