### PR TITLE
Fix favicon path on subpages

### DIFF
--- a/algosone-ai/pages/about/algosone.ai/about/index.html
+++ b/algosone-ai/pages/about/algosone.ai/about/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport"/>
 <meta content="ie=edge" http-equiv="X-UA-Compatible"/>
-<link href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg" rel="icon" sizes="40x38" type="image/svg"/>
+<link href="../assets/themes/common/assets/images/logo.svg" rel="icon" sizes="40x38" type="image/svg"/>
 <script defer="" src="../../ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script defer="" src="../../ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
 <link href="../../cdn.jsdelivr.net/npm/swiper%4011.0.4/swiper-bundle.min.css" rel="stylesheet"/>

--- a/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html
+++ b/algosone-ai/pages/affiliates/algosone.ai/affiliates/index.html
@@ -10,7 +10,7 @@
     <link
       rel="icon"
       type="image/svg"
-      href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg"
+      href="../assets/themes/common/assets/images/logo.svg"
       sizes="40x38"
     />
     <script

--- a/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
+++ b/algosone-ai/pages/ai-crypto-trading/algosone.ai/ai-crypto-trading/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport"/>
   <meta content="ie=edge" http-equiv="X-UA-Compatible"/>
-  <link href="https://aqronix.ai/assets/themes/common/assets/icons/logo-small.svg" rel="icon" sizes="40x38" type="image/svg"/>
+  <link href="../assets/themes/common/assets/images/logo.svg" rel="icon" sizes="40x38" type="image/svg"/>
   <script defer="" src="../../ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js">
   </script>
   <script defer="" src="../../ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js">

--- a/algosone-ai/pages/contact/algosone.ai/contact/index.html
+++ b/algosone-ai/pages/contact/algosone.ai/contact/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport"/>
   <meta content="ie=edge" http-equiv="X-UA-Compatible"/>
-  <link href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg" rel="icon" sizes="40x38" type="image/svg"/>
+  <link href="../assets/themes/common/assets/images/logo.svg" rel="icon" sizes="40x38" type="image/svg"/>
   <script defer="" src="../../ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js">
   </script>
   <script defer="" src="../../ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js">

--- a/algosone-ai/pages/contact/algosone.ai/contact/transparent/index.html
+++ b/algosone-ai/pages/contact/algosone.ai/contact/transparent/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport"/>
   <meta content="ie=edge" http-equiv="X-UA-Compatible"/>
-  <link href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg" rel="icon" sizes="40x38" type="image/svg"/>
+  <link href="../../assets/themes/common/assets/images/logo.svg" rel="icon" sizes="40x38" type="image/svg"/>
   <script defer="" src="../../../ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js">
   </script>
   <script defer="" src="../../../ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js">
@@ -84,7 +84,7 @@ gtag("config", "GT-WR9QBQT");
      </div>
      <div class="ptr-preloader">
       <div class="ptr-prel-content">
-       <img alt="Logo" class="ptr-prel-image tt-logo-light" src="../../assets/themes/common/assets/images/logo.svg"/>
+       <img alt="Logo" class="ptr-prel-image tt-logo-light" src="../../../assets/themes/common/assets/images/logo.svg"/>
        <div class="percentage">
         <span id="percentage">
          15
@@ -106,8 +106,8 @@ gtag("config", "GT-WR9QBQT");
        <div class="tt-header-col">
         <div class="tt-logo">
          <a href="/algosone-ai/pages/home/algosone.ai/index.html">
-          <img alt="algosone uk" class="tt-logo-light magnetic-item cursor-alter" src="../../assets/themes/common/assets/images/logo.svg" title="AlgosOne"/>
-          <img alt="algosone uk" class="tt-logo-dark magnetic-item cursor-alter" src="../../assets/themes/common/assets/images/logo.svg" title="AlgosOne"/>
+          <img alt="algosone uk" class="tt-logo-light magnetic-item cursor-alter" src="../../../assets/themes/common/assets/images/logo.svg" title="AlgosOne"/>
+          <img alt="algosone uk" class="tt-logo-dark magnetic-item cursor-alter" src="../../../assets/themes/common/assets/images/logo.svg" title="AlgosOne"/>
           <span class="text">
            AlgosOne
           </span>
@@ -470,7 +470,7 @@ gtag("config", "GT-WR9QBQT");
         <div class="row-2">
          <div class="col-left">
           <a class="logo" href="/algosone-ai/pages/home/algosone.ai/index.html">
-           <img alt="Logo" class="tt-logo-light magnetic-item cursor-alter" src="../../assets/themes/common/assets/images/logo.svg"/>
+           <img alt="Logo" class="tt-logo-light magnetic-item cursor-alter" src="../../../assets/themes/common/assets/images/logo.svg"/>
            <span class="text">
             AlgosOne
            </span>

--- a/algosone-ai/pages/faq/algosone.ai/faq/index.html
+++ b/algosone-ai/pages/faq/algosone.ai/faq/index.html
@@ -10,7 +10,7 @@
     <link
       rel="icon"
       type="image/svg"
-      href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg"
+      href="../assets/themes/common/assets/images/logo.svg"
       sizes="40x38"
     />
     <script

--- a/algosone-ai/pages/markets/algosone.ai/markets/index.html
+++ b/algosone-ai/pages/markets/algosone.ai/markets/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport"/>
   <meta content="ie=edge" http-equiv="X-UA-Compatible"/>
-  <link href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg" rel="icon" sizes="40x38" type="image/svg"/>
+  <link href="../assets/themes/common/assets/images/logo.svg" rel="icon" sizes="40x38" type="image/svg"/>
   <script defer="" src="../../ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js">
   </script>
   <script defer="" src="../../ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js">

--- a/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
+++ b/algosone-ai/pages/profitability/algosone.ai/profitability/index.html
@@ -10,7 +10,7 @@
     <link
       rel="icon"
       type="image/svg"
-      href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg"
+      href="../assets/themes/common/assets/images/logo.svg"
       sizes="40x38"
     />
     <script

--- a/algosone-ai/pages/reviews/algosone.ai/reviews/index.html
+++ b/algosone-ai/pages/reviews/algosone.ai/reviews/index.html
@@ -10,7 +10,7 @@
     <link
       rel="icon"
       type="image/svg"
-      href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg"
+      href="../assets/themes/common/assets/images/logo.svg"
       sizes="40x38"
     />
     <script

--- a/algosone-ai/pages/technology/algosone.ai/technology/index.html
+++ b/algosone-ai/pages/technology/algosone.ai/technology/index.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport"/>
 <meta content="ie=edge" http-equiv="X-UA-Compatible"/>
-<link href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg" rel="icon" sizes="40x38" type="image/svg"/>
+<link href="../assets/themes/common/assets/images/logo.svg" rel="icon" sizes="40x38" type="image/svg"/>
 <script defer="" src="../../ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script defer="" src="../../ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
 <link href="../../cdn.jsdelivr.net/npm/swiper%4011.0.4/swiper-bundle.min.css" rel="stylesheet"/>

--- a/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html
+++ b/algosone-ai/pages/trust-center/algosone.ai/trust-center/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport"/>
   <meta content="ie=edge" http-equiv="X-UA-Compatible"/>
-  <link href="https://algosone.ai/assets/themes/common/assets/icons/logo-small.svg" rel="icon" sizes="40x38" type="image/svg"/>
+  <link href="../assets/themes/common/assets/images/logo.svg" rel="icon" sizes="40x38" type="image/svg"/>
   <script defer="" src="../../ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js">
   </script>
   <script defer="" src="../../ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js">


### PR DESCRIPTION
## Summary
- fix favicon links so pages show the Aqronix logo in browser tabs

## Testing
- `grep -n "rel=\"icon\"" algosone-ai/pages/contact/algosone.ai/contact/transparent/index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_685f8f4644fc83209cccaacbfa4954f6